### PR TITLE
idgen: Allow temporary directory to be specified in HashDecorator

### DIFF
--- a/simplekv/idgen.py
+++ b/simplekv/idgen.py
@@ -32,8 +32,9 @@ class HashDecorator(StoreDecorator):
     *hashlib.sha1*.
     """
 
-    def __init__(self, decorated_store, hashfunc=hashlib.sha1):
+    def __init__(self, decorated_store, hashfunc=hashlib.sha1, tmpdir=None):
         self.hashfunc = hashfunc
+        self.tmpdir = tmpdir
         super(HashDecorator, self).__init__(decorated_store)
 
     def put(self, key, data):
@@ -60,7 +61,7 @@ class HashDecorator(StoreDecorator):
                         phash.hexdigest(),
                         file)
             else:
-                tmpfile = tempfile.NamedTemporaryFile(delete=False)
+                tmpfile = tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False)
                 try:
                     while True:
                         buf = file.read(bufsize)


### PR DESCRIPTION
It's a good idea to be able to specify a temp dir on the same filesystem than the underlying FilesystemStore so that os.rename can be used instead of copying the file if /tmp isn't on the same filesystem for example.
