### PR TITLE
FilesystemStore: Add a size(key) method to return the file size on disk

### DIFF
--- a/simplekv/fs.py
+++ b/simplekv/fs.py
@@ -107,7 +107,12 @@ class FilesystemStore(UrlKeyValueStore):
 
     def iter_keys(self):
         return iter(self.keys())
-
+        
+    def size(self, key):
+    	self._check_valid_key(key)
+		if not key in self:
+			raise KeyError(key)
+		return os.stat(self._build_filename(key)).st_size
 
 class WebFilesystemStore(FilesystemStore):
     """FilesystemStore that supports generating URLs suitable for web


### PR DESCRIPTION
It's useful to be able to return the size of the file on disk.

I'm not sure whether this is the right approach or if the size() should be defined on the base Store class and implemented across all backends...
