### PR TITLE
HashDecorator: Check if temp file exists before unlinking

### DIFF
--- a/simplekv/idgen.py
+++ b/simplekv/idgen.py
@@ -76,7 +76,8 @@ class HashDecorator(StoreDecorator):
                         tmpfile.name
                     )
                 finally:
-                    os.unlink(tmpfile.name)
+                    if os.path.exists(tmpfile.name):
+                        os.unlink(tmpfile.name)
         return self._dstore.put_file(key, file)
 
 


### PR DESCRIPTION
When HashDecorator is combined with FilesystemStore, the put_file operation could result in an os.rename() of the tempfile to its final destination. If that happens, then there's no more temp file to unlink causing an OSError. This will check first if the file still exists before unlinking.
