### PR TITLE
Opened connection in _put module has to be closed

### DIFF
--- a/simplekv/db/sql.py
+++ b/simplekv/db/sql.py
@@ -62,6 +62,7 @@ class SQLAlchemyStore(KeyValueStore):
 
             # commit happens here
 
+        con.close()
         return key
 
     def _put_file(self, key, file):


### PR DESCRIPTION
Opened connection in _put module has to be closed. Otherwise, store.put more than 6 times in database store causes a deadlock
