### PR TITLE
Improves SQLAlchemy has_key method using SQL EXISTS clause

### DIFF
--- a/simplekv/db/sql.py
+++ b/simplekv/db/sql.py
@@ -7,7 +7,7 @@ from .._compat import imap
 from .. import KeyValueStore
 
 from sqlalchemy import MetaData, Table, Column, String, LargeBinary, select,\
-                       delete, insert, update
+                       delete, insert, update, exists
 
 
 class SQLAlchemyStore(KeyValueStore):
@@ -22,9 +22,9 @@ class SQLAlchemyStore(KeyValueStore):
         )
 
     def _has_key(self, key):
-        return None != self.bind.execute(
-            select([self.table.c.key], self.table.c.key == key).limit(1)
-        ).first()
+        return self.bind.execute(
+            select([exists().where(self.table.c.key == key)])
+        ).scalar()
 
     def _delete(self, key):
         self.bind.execute(


### PR DESCRIPTION
It uses SQL EXISTS clause instead of fetching a record and comparing it against None.

See the current query:

```
 return None != self.bind.execute(
        select([self.table.c.key], self.table.c.key == key).limit(1)
    ).first()
```

This fragment of code can result a bit problematic due to de comparision
of a sqlalchemy RowProxy against None, which should be using the `is` operator also.

The proposed query:

```
return self.bind.execute(
    select([exists().where(self.table.c.key == key)])
).scalar()
```

Returns a boolean directly from the database,
and it should be allegedly faster while keeping it ANSI SQL.

Congrats for the library, it's easy to use and fun to extend.
