### PR TITLE
Fixed an issue that would appear in redis < 2.6

### DIFF
--- a/simplekv/memory/redisstore.py
+++ b/simplekv/memory/redisstore.py
@@ -48,7 +48,8 @@ class RedisStore(TimeToLiveMixin, KeyValueStore):
             # to set a default timeout on keys
             self.redis.set(key, value)
         else:
-            self.redis.psetex(key, int(ttl_secs * 1000), value)
+            #updated for redis version 2.4.10 - psetex requires redis>2.6
+            self.redis.setex(key, int(ttl_secs), value)
         return key
 
     def _put_file(self, key, file, ttl_secs):


### PR DESCRIPTION
When using AWS you are forced to work with python<2.7, so redis is not up to date either. It's a very small fix, psetex uses miliseconds while setex uses seconds, but as we use a timedelta * 1000, setex is sufficient.