### PR TITLE
Fix #28

### DIFF
--- a/simplekv/decorator.py
+++ b/simplekv/decorator.py
@@ -33,11 +33,14 @@ class KeyTransformingDecorator(StoreDecorator):
     def _unmap_key(self, key):
         return key
 
+    def _filter(self, key):
+        return True
+
     def __contains__(self, key):
         return self._map_key(key) in self._dstore
 
     def __iter__(self):
-        return map(self._unmap_key, iter(self._dstore))
+        return map(self._unmap_key, filter(self._filter, iter(self._dstore)))
 
     def delete(self, key):
         return self._dstore.delete(self._map_key(key))
@@ -49,10 +52,14 @@ class KeyTransformingDecorator(StoreDecorator):
         return self._dstore.get_file(self._map_key(key), *args, **kwargs)
 
     def iter_keys(self):
-        return map(self._unmap_key, self._dstore.iter_keys())
+        return map(self._unmap_key, filter(self._filter, self._dstore.iter_keys()))
 
     def keys(self):
-        return list(map(self._unmap_key, self._dstore.keys()))
+        """Return a list of keys currently in store, in any order
+
+        :raises IOError: If there was an error accessing the store.
+        """
+        return list(self.iter_keys())
 
     def open(self, key):
         return self._dstore.open(self._map_key(key))
@@ -83,11 +90,12 @@ class PrefixDecorator(KeyTransformingDecorator):
         super(PrefixDecorator, self).__init__(store)
         self.prefix = prefix
 
+    def _filter(self, key):
+        return key.startswith(self.prefix)
+
     def _map_key(self, key):
         self._check_valid_key(key)
         return self.prefix + key
 
     def _unmap_key(self, key):
-        assert key.startswith(self.prefix)
-
         return key[len(self.prefix):]

--- a/tests/test_prefix_decorator.py
+++ b/tests/test_prefix_decorator.py
@@ -1,6 +1,6 @@
-import codecs
-import os
-from simplekv._compat import BytesIO
+import random
+import string
+from simplekv._compat import BytesIO, xrange
 from simplekv.memory import DictStore
 from simplekv.decorator import PrefixDecorator
 import pytest
@@ -21,12 +21,13 @@ class TestPrefixDecorator(BasicStore):
     @pytest.fixture
     def store(self, prefix):
         def randstring():
-            return codecs.encode(os.urandom(8), 'hex')
+            return u''.join(random.choice(string.ascii_lowercase)
+                            for _ in xrange(8))
 
         base_store = DictStore()
-        base_store.put(randstring(), randstring())
-        base_store.put(randstring(), randstring())
-        base_store.put(randstring(), randstring())
+        base_store.put(randstring(), randstring().encode('utf8'))
+        base_store.put(randstring(), randstring().encode('utf8'))
+        base_store.put(randstring(), randstring().encode('utf8'))
 
         return PrefixDecorator(prefix, base_store)
 

--- a/tests/test_prefix_decorator.py
+++ b/tests/test_prefix_decorator.py
@@ -1,3 +1,5 @@
+import codecs
+import os
 from simplekv._compat import BytesIO
 from simplekv.memory import DictStore
 from simplekv.decorator import PrefixDecorator
@@ -18,7 +20,15 @@ class TestPrefixDecorator(BasicStore):
 
     @pytest.fixture
     def store(self, prefix):
-        return PrefixDecorator(prefix, DictStore())
+        def randstring():
+            return codecs.encode(os.urandom(8), 'hex')
+
+        base_store = DictStore()
+        base_store.put(randstring(), randstring())
+        base_store.put(randstring(), randstring())
+        base_store.put(randstring(), randstring())
+
+        return PrefixDecorator(prefix, base_store)
 
     def test_put_returns_correct_key(self, store, prefix, key, value):
         assert key == store.put(key, value)


### PR DESCRIPTION
This fixes the issue where PrefixDecorator-stores couldn't deal with other, non-prefixed keys in the base store (#28).

The first commit changes the test suite, adding extra keys to the base store which shows the issue. The second commit contains the fix.

Open issues with this patch: 

1. Now **all** tests on PrefixDecorator-Stores run with extra keys in the base store. Maybe it makes sense to run all tests with **and** without those keys. But I was hesitant to blow up the number of tests by a factor of two.

2. I removed the call to _check_valid_key from _unmap_key, since at this point, `key` is untransformed and I think it's the responsibility of the base store to check those. If at all, we should do our own check after unmapping. But I'm not completely sure if that is the right way.

A more general point: The way the KeyTransformingDecorator is written right now, it is entirely possible to allow different keys than the base store, e.g. because the transformation can transform keys to/from whatever the base store allows. A subclass of KeyTransformingDecorator only has to define _check_valid_key() for this to work. But the tests via basic_store.py use specific invalid keys from conftest.py to check if `KeyError`s are being raised. I noticed this because with a non-empty prefix, an empty key is technically valid, but the testsuite expects it to fail, even on a PrefixDecorator.