### PR TITLE
Ignore directory entries in FilesystemStore

### DIFF
--- a/simplekv/fs.py
+++ b/simplekv/fs.py
@@ -57,7 +57,7 @@ class FilesystemStore(KeyValueStore, UrlMixin):
         os.chmod(filename, perm)
 
     def _has_key(self, key):
-        return os.path.exists(self._build_filename(key))
+        return os.path.isfile(self._build_filename(key))
 
     def _open(self, key):
         try:
@@ -103,7 +103,8 @@ class FilesystemStore(KeyValueStore, UrlMixin):
         return 'file://' + location
 
     def keys(self):
-        return os.listdir(self.root)
+        return [item for item in os.listdir(self.root)
+                if not os.path.isdir(os.path.join(self.root, item))]
 
     def iter_keys(self):
         return iter(self.keys())

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -139,3 +139,23 @@ class TestWebFileStore(TestBaseFilesystemStore):
         assert store.url_for(key) == expected
 
         mock_callable.assert_called_with(store, key)
+
+# test handling of directory entries in the file system
+class TestFilesystemStoreDirs(TestBaseFilesystemStore):
+    @pytest.fixture
+    def store(self, tmpdir):
+        os.mkdir(os.path.join(tmpdir, 'subdir1'))
+        os.mkdir(os.path.join(tmpdir, 'subdir2'))
+        fname = os.path.join(tmpdir, 'subdir2', 'testfile')
+        with open(fname, 'a'):
+            os.utime(fname, None)
+        return FilesystemStore(tmpdir)
+
+    def test_listing_keys_ignores_subdirs(self, store):
+        assert store.keys() == []
+
+        src = BytesIO()
+
+        key = store.put_file('test123', src)
+
+        assert store.keys() == ['test123']

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -140,6 +140,7 @@ class TestWebFileStore(TestBaseFilesystemStore):
 
         mock_callable.assert_called_with(store, key)
 
+
 # test handling of directory entries in the file system
 class TestFilesystemStoreDirs(TestBaseFilesystemStore):
     @pytest.fixture
@@ -156,6 +157,6 @@ class TestFilesystemStoreDirs(TestBaseFilesystemStore):
 
         src = BytesIO()
 
-        key = store.put_file('test123', src)
+        store.put_file('test123', src)
 
         assert store.keys() == ['test123']


### PR DESCRIPTION
Currently, if the root of a FilesystemStore contains directories, the .keys()-method also returns those entries, which lead to errors in .put()/.get() etc.

This patch removes directory entries from .keys() and ._has_key()
