### PR TITLE
Support for Azure Blob Block Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .cache
 __pycache__
 simplekv.egg-info
+boto_credentials.ini
+azure_credentials.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.tox
+.cache
+__pycache__
+simplekv.egg-info

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -70,7 +70,30 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _put_file(self, key, file):
         try:
-            self.block_blob_service.create_blob_from_path(self.container,  self.__generate_key(key), file)
+            self.block_blob_service.create_blob_from_stream(self.container, self.__generate_key(key), file)
+            return key
+        except AzureHttpError as ex:
+            raise IOError(str(ex))
+
+    def _get_file(self, key, file):
+        try:
+            self.block_blob_service.get_blob_to_stream(self.container, self.__generate_key(key), file)
+        except AzureHttpError as ex:
+            raise IOError(str(ex))
+        except AzureException as ex:
+            raise KeyError(key) 
+
+    def _get_filename(self, key, filename):
+        try:
+            self.block_blob_service.get_blob_to_path(self.container, self.__generate_key(key), filename)
+        except AzureHttpError as ex:
+            raise IOError(str(ex))
+        except AzureException as ex:
+            raise KeyError(key)
+
+    def _put_filename(self, key, filename):
+        try:
+            self.block_blob_service.create_blob_from_path(self.container, self.__generate_key(key), filename)
             return key
         except AzureHttpError as ex:
             raise IOError(str(ex))

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -10,8 +10,8 @@ from azure.storage._error import AzureHttpException
 import io
 
 class AzureBlockBlobStorage(KeyValueStore):
-    def __init__(self, block_blob_service, container, public=False, prefix=''):
-        self.block_blob_service = block_blob_service
+    def __init__(self, account, container, public=False, prefix=''):
+        self.block_blob_service = account.create_block_blob_service()
         self.container = container
         self.public = public
         self.prefix = prefix

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -26,7 +26,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _delete(self, key):
         try:
-            self.block_blob_service.delete_blob(container, self.__generate_key(key))
+            self.block_blob_service.delete_blob(self.container, self.__generate_key(key))
         except AzureHttpError as ex:
             raise IOError(str(ex))
         except AzureException as ex:
@@ -34,7 +34,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _get(self, key):
         try:
-            return self.get_blob_to_text(container,  self.__generate_key(key))
+            return self.get_blob_to_text(self.container,  self.__generate_key(key))
         except AzureHttpError as ex:
             raise IOError(str(ex))
         except AzureException as ex:
@@ -42,13 +42,13 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _has_key(self, key):
         try:
-            return self.block_blob_service.exists(container,  self.__generate_key(key))
+            return self.block_blob_service.exists(self.container,  self.__generate_key(key))
         except AzureHttpError as ex:
             raise IOError(str(ex))
 
     def iter_keys(self):
         try:
-            return self.block_blob_service.list_blobs(container)
+            return self.block_blob_service.list_blobs(self.container)
         except AzureHttpError as ex:
             raise IOError(str(ex))
 
@@ -56,21 +56,21 @@ class AzureBlockBlobStorage(KeyValueStore):
     def _open(self, key):
         try:
             output_stream = io.BytesIO()
-            self.block_blob_service.get_blob_to_stream(container,  self.__generate_key(key), output_stream)
+            self.block_blob_service.get_blob_to_stream(self.container,  self.__generate_key(key), output_stream)
             return output_stream
         except AzureHttpError as ex:
             raise IOError(str(ex))
 
     def _put(self, key, data):
         try:
-            self.block_blob_service.create_blob_from_text(container,  self.__generate_key(key), data)
+            self.block_blob_service.create_blob_from_text(self.container,  self.__generate_key(key), data)
             return key
         except AzureHttpError as ex:
             raise IOError(str(ex))
 
     def _put_file(self, key, file):
         try:
-            self.block_blob_service.create_blob_from_path(container,  self.__generate_key(key), file)
+            self.block_blob_service.create_blob_from_path(self.container,  self.__generate_key(key), file)
             return key
         except AzureHttpError as ex:
             raise IOError(str(ex))

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -18,9 +18,12 @@ class AzureBlockBlobStorage(KeyValueStore):
 
         self.block_blob_service.create_container(container, public_access=PublicAccess.Container if public else None)
 
+    def __generate_key(self, key)
+        return self.prefix + key
+
     def _delete(self, key):
         try:
-            self.block_blob_service.delete_blob(container, key)
+            self.block_blob_service.delete_blob(container, self.__generate_key(key))
         except AzureHttpError as ex:
             raise IOError(str(ex))
         except AzureException as ex:
@@ -28,7 +31,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _get(self, key):
         try:
-            return self.get_blob_to_text(container, key)
+            return self.get_blob_to_text(container,  self.__generate_key(key)
         except AzureHttpError as ex:
             raise IOError(str(ex))
         except AzureException as ex:
@@ -36,7 +39,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _has_key(self, key):
         try:
-            return self.block_blob_service.exists(container, key)
+            return self.block_blob_service.exists(container,  self.__generate_key(key)
         raise AzureHttpException as ex:
             raise IOError(str(ex))
 
@@ -50,21 +53,21 @@ class AzureBlockBlobStorage(KeyValueStore):
     def _open(self, key):
         try:
             output_stream = io.BytesIO()
-            self.block_blob_service.get_blob_to_stream(container, key, output_stream)
+            self.block_blob_service.get_blob_to_stream(container,  self.__generate_key(key), output_stream)
             return output_stream
         raise AzureHttpException as ex:
             raise IOError(str(ex))
 
     def _put(self, key, data):
         try:
-            self.block_blob_service.create_blob_from_text(container, key, data)
+            self.block_blob_service.create_blob_from_text(container,  self.__generate_key(key), data)
             return key
         raise AzureHttpException as ex:
             raise IOError(str(ex))
 
     def _put_file(self, key, file):
         try:
-            self.block_blob_service.create_blob_from_path(container, key, file)
+            self.block_blob_service.create_blob_from_path(container,  self.__generate_key(key), file)
             return key
         raise AzureHttpException as ex:
             raise IOError(str(ex))

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -34,7 +34,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _get(self, key):
         try:
-            return self.get_blob_to_text(self.container,  self.__generate_key(key))
+            return self.block_blob_service.get_blob_to_text(self.container,  self.__generate_key(key)).content
         except AzureHttpError as ex:
             raise IOError(str(ex))
         except AzureException as ex:

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -61,7 +61,8 @@ class AzureBlockBlobStorage(KeyValueStore):
         try:
             output_stream = io.BytesIO()
             self.block_blob_service.get_blob_to_stream(self.container,  self.__generate_key(key), output_stream)
-            return output_stream
+            dummy = type('Dummy', (object,), { "read": lambda n=0: output_stream.getvalue() if n == 0 else output_stream.getvalue()[:n]})
+            return dummy
         except AzureHttpError as ex:
             raise IOError(str(ex))
 

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -34,8 +34,8 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _get(self, key):
         try:
-            blob = self.block_blob_service.get_blob_to_stream(self.container, self.__generate_key(key), io.BytesIO())
-            if 'type' in blob.metadata and blob.metadata['type'] == 'str':
+            metadata = self.block_blob_service.get_blob_metadata(self.container, self.__generate_key(key))
+            if 'type' in metadata and metadata['type'] == 'str':
                 return self.block_blob_service.get_blob_to_text(self.container,  self.__generate_key(key)).content
             else:
                 return self.block_blob_service.get_blob_to_bytes(self.container,  self.__generate_key(key)).content

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 # coding=utf8
 
+import io
+
 from azure.storage import CloudStorageAccount
 from azure.storage.blob import BlockBlobService
 from azure.storage.blob import PublicAccess
 from azure.storage._error import AzureException
-from azure.storage._error import AzureHttpException
+from azure.storage._error import AzureHttpError
 
-import io
+from . import KeyValueStore
+
 
 class AzureBlockBlobStorage(KeyValueStore):
     def __init__(self, account, container, public=False, prefix=''):
@@ -18,7 +21,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
         self.block_blob_service.create_container(container, public_access=PublicAccess.Container if public else None)
 
-    def __generate_key(self, key)
+    def __generate_key(self, key):
         return self.prefix + key
 
     def _delete(self, key):
@@ -31,7 +34,7 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _get(self, key):
         try:
-            return self.get_blob_to_text(container,  self.__generate_key(key)
+            return self.get_blob_to_text(container,  self.__generate_key(key))
         except AzureHttpError as ex:
             raise IOError(str(ex))
         except AzureException as ex:
@@ -39,14 +42,14 @@ class AzureBlockBlobStorage(KeyValueStore):
 
     def _has_key(self, key):
         try:
-            return self.block_blob_service.exists(container,  self.__generate_key(key)
-        raise AzureHttpException as ex:
+            return self.block_blob_service.exists(container,  self.__generate_key(key))
+        except AzureHttpError as ex:
             raise IOError(str(ex))
 
     def iter_keys(self):
         try:
             return self.block_blob_service.list_blobs(container)
-        raise AzureHttpException as ex:
+        except AzureHttpError as ex:
             raise IOError(str(ex))
 
 
@@ -55,19 +58,19 @@ class AzureBlockBlobStorage(KeyValueStore):
             output_stream = io.BytesIO()
             self.block_blob_service.get_blob_to_stream(container,  self.__generate_key(key), output_stream)
             return output_stream
-        raise AzureHttpException as ex:
+        except AzureHttpError as ex:
             raise IOError(str(ex))
 
     def _put(self, key, data):
         try:
             self.block_blob_service.create_blob_from_text(container,  self.__generate_key(key), data)
             return key
-        raise AzureHttpException as ex:
+        except AzureHttpError as ex:
             raise IOError(str(ex))
 
     def _put_file(self, key, file):
         try:
             self.block_blob_service.create_blob_from_path(container,  self.__generate_key(key), file)
             return key
-        raise AzureHttpException as ex:
+        except AzureHttpError as ex:
             raise IOError(str(ex))

--- a/simplekv/azure.py
+++ b/simplekv/azure.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# coding=utf8
+
+from azure.storage import CloudStorageAccount
+from azure.storage.blob import BlockBlobService
+from azure.storage.blob import PublicAccess
+from azure.storage._error import AzureException
+from azure.storage._error import AzureHttpException
+
+import io
+
+class AzureBlockBlobStorage(KeyValueStore):
+    def __init__(self, block_blob_service, container, public=False, prefix=''):
+        self.block_blob_service = block_blob_service
+        self.container = container
+        self.public = public
+        self.prefix = prefix
+
+        self.block_blob_service.create_container(container, public_access=PublicAccess.Container if public else None)
+
+    def _delete(self, key):
+        try:
+            self.block_blob_service.delete_blob(container, key)
+        except AzureHttpError as ex:
+            raise IOError(str(ex))
+        except AzureException as ex:
+            raise KeyError(key)
+
+    def _get(self, key):
+        try:
+            return self.get_blob_to_text(container, key)
+        except AzureHttpError as ex:
+            raise IOError(str(ex))
+        except AzureException as ex:
+            raise KeyError(key)
+
+    def _has_key(self, key):
+        try:
+            return self.block_blob_service.exists(container, key)
+        raise AzureHttpException as ex:
+            raise IOError(str(ex))
+
+    def iter_keys(self):
+        try:
+            return self.block_blob_service.list_blobs(container)
+        raise AzureHttpException as ex:
+            raise IOError(str(ex))
+
+
+    def _open(self, key):
+        try:
+            output_stream = io.BytesIO()
+            self.block_blob_service.get_blob_to_stream(container, key, output_stream)
+            return output_stream
+        raise AzureHttpException as ex:
+            raise IOError(str(ex))
+
+    def _put(self, key, data):
+        try:
+            self.block_blob_service.create_blob_from_text(container, key, data)
+            return key
+        raise AzureHttpException as ex:
+            raise IOError(str(ex))
+
+    def _put_file(self, key, file):
+        try:
+            self.block_blob_service.create_blob_from_path(container, key, file)
+            return key
+        raise AzureHttpException as ex:
+            raise IOError(str(ex))

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -31,7 +31,7 @@ def create_azure_account(credentials):
     account_key = credentials['account_key']
     return CloudStorageAccount(account_name=account_name, account_key=account_key) 
 
-class TestAzureStorage(BasicStore, UrlStore):
+class TestAzureStorage(BasicStore):
     @pytest.fixture(params=['', '/test-prefix'])
     def prefix(self, request):
         return request.param

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -1,0 +1,64 @@
+from simplekv._compat import ConfigParser
+from azure.storage import CloudStorageAccount
+from uuid import uuid4 as uuid
+
+import pytest
+
+from .. import AzureBlockBlobStorage
+
+def load_azure_credentials():
+    # loaded from the same place as tox.ini. here's a sample
+    #
+    # [my-azure-1]
+    # account_name=foo
+    # account_key=bar
+
+    # [my-azure-2]
+    # account_name=bla
+    # account_key=blubber
+    cfg_fn = 'azure_credentials.ini'
+
+    parser = ConfigParser()
+    if not parser.read(cfg_fn):
+        pytest.skip('file {} not found'.format(cfg_fn))
+
+    # Only one entry is currently supported
+    for section in parser.sections():
+        yield {
+            'account_name': parser.get(section, 'account_name'),
+            'account_key': parser.get(section, 'account_key'),
+        }
+
+azure_credentials = list(load_azure_credentials())
+
+def create_azure_account(credentials)
+    account_name = config.STORAGE_ACCOUNT_NAME
+    account_key = config.STORAGE_ACCOUNT_KEY
+    return CloudStorageAccount(account_name=account_name, account_key=account_key) 
+
+def generate_container_name():
+    return 'testrun-bucket-{}'.format(uuid())
+
+@pytest.fixture(params=azure_credentials,
+                ids=[c['account_name'] for c in azure_credentials])
+def credentials(request):
+    return request.param
+
+@pytest.yield_fixture()
+def account(credentials):
+    with azure_credentials(**credentials) as account:
+        yield account
+
+class TestAzureStorage(BasicStore, UrlStore):
+    @pytest.fixture(params=['', '/test-prefix'])
+    def prefix(self, request):
+        return request.param
+
+    @pytest.fixture(params='testrun-bucket-{}'.format(uuid()))
+    def container(self, request):
+        return request.param
+
+    @pytest.fixture
+    def store(self, container, prefix):
+        account = create_azure_account(credentials)
+        return AzureBlockBlobStorage(account, container, public=false, prefix)

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -1,10 +1,12 @@
-from simplekv._compat import ConfigParser
 from azure.storage import CloudStorageAccount
 from uuid import uuid4 as uuid
-
 import pytest
 
-from .. import AzureBlockBlobStorage
+from simplekv._compat import ConfigParser
+from simplekv.azure import AzureBlockBlobStorage
+
+from basic_store import BasicStore
+from url_store import UrlStore
 
 def load_azure_credentials():
     # loaded from the same place as tox.ini. here's a sample
@@ -31,7 +33,7 @@ def load_azure_credentials():
 
 azure_credentials = list(load_azure_credentials())
 
-def create_azure_account(credentials)
+def create_azure_account(credentials):
     account_name = config.STORAGE_ACCOUNT_NAME
     account_key = config.STORAGE_ACCOUNT_KEY
     return CloudStorageAccount(account_name=account_name, account_key=account_key) 
@@ -61,4 +63,4 @@ class TestAzureStorage(BasicStore, UrlStore):
     @pytest.fixture
     def store(self, container, prefix):
         account = create_azure_account(credentials)
-        return AzureBlockBlobStorage(account, container, public=false, prefix)
+        return AzureBlockBlobStorage(account, container, prefix=prefix, public=False)

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -11,56 +11,37 @@ from url_store import UrlStore
 def load_azure_credentials():
     # loaded from the same place as tox.ini. here's a sample
     #
-    # [my-azure-1]
+    # [my-azure-storage-account]
     # account_name=foo
     # account_key=bar
-
-    # [my-azure-2]
-    # account_name=bla
-    # account_key=blubber
     cfg_fn = 'azure_credentials.ini'
 
     parser = ConfigParser()
     if not parser.read(cfg_fn):
         pytest.skip('file {} not found'.format(cfg_fn))
 
-    # Only one entry is currently supported
     for section in parser.sections():
-        yield {
+        return {
             'account_name': parser.get(section, 'account_name'),
             'account_key': parser.get(section, 'account_key'),
         }
 
-azure_credentials = list(load_azure_credentials())
-
 def create_azure_account(credentials):
-    account_name = config.STORAGE_ACCOUNT_NAME
-    account_key = config.STORAGE_ACCOUNT_KEY
+    account_name = credentials['account_name']
+    account_key = credentials['account_key']
     return CloudStorageAccount(account_name=account_name, account_key=account_key) 
-
-def generate_container_name():
-    return 'testrun-bucket-{}'.format(uuid())
-
-@pytest.fixture(params=azure_credentials,
-                ids=[c['account_name'] for c in azure_credentials])
-def credentials(request):
-    return request.param
-
-@pytest.yield_fixture()
-def account(credentials):
-    with azure_credentials(**credentials) as account:
-        yield account
 
 class TestAzureStorage(BasicStore, UrlStore):
     @pytest.fixture(params=['', '/test-prefix'])
     def prefix(self, request):
         return request.param
 
-    @pytest.fixture(params='testrun-bucket-{}'.format(uuid()))
+    # @pytest.fixture(params='testrun-bucket-{}'.format(uuid()))
+    @pytest.fixture(params=[uuid()])
     def container(self, request):
         return request.param
 
     @pytest.fixture
     def store(self, container, prefix):
-        account = create_azure_account(credentials)
+        account = create_azure_account(load_azure_credentials())
         return AzureBlockBlobStorage(account, container, prefix=prefix, public=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,py35
 
 [pytest]
 pep8ignore = test_* E402

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps=
   pymysql
   pymongo
   dulwich
+  azure
+  azure-storage
 commands=py.test -rs --pep8 --doctest-modules simplekv/idgen.py simplekv/fs.py tests
 
 # the environment below omits python-memcached, as that package does not even


### PR DESCRIPTION
This pull request adds support for Azure Blob Block Storage.
It expects an `azure_credentials.ini` file in the following format:

```
[my-azure]
account_name: foobar
account_key: blablubber
```

Only one entry is currently supported.

Support for other Azure environments (Germany, China, USGov) depends on the Azure Python SDK support. I've already filed an issue at [https://github.com/Azure/azure-storage-python/issues/227](https://github.com/Azure/azure-storage-python/issues/227)
