### PR TITLE
use imap() from _compat module

### DIFF
--- a/simplekv/net/botostore.py
+++ b/simplekv/net/botostore.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf8
 
-from itertools import imap
+from .._compat import imap
 
 from boto.exception import BotoClientError, BotoServerError,\
                            StorageResponseError


### PR DESCRIPTION
`net/botostore.py` imports `imap()` from the PY2 stdlib.
This patch changes the import to use the already available definition from the `_compat` module.

This doesn't restore full PY3-compatibility, though.