### PR TITLE
adapt value handling in memcached-backend to PY3

### DIFF
--- a/simplekv/memory/memcachestore.py
+++ b/simplekv/memory/memcachestore.py
@@ -4,6 +4,7 @@
 from io import BytesIO
 
 from .. import KeyValueStore, TimeToLiveMixin, FOREVER, NOT_SET
+from .._compat import PY2
 
 
 class MemcacheStore(TimeToLiveMixin, KeyValueStore):
@@ -25,7 +26,11 @@ class MemcacheStore(TimeToLiveMixin, KeyValueStore):
         rv = self.mc.get(key.encode('ascii'))
         if None == rv:
             raise KeyError(key)
-        return rv
+        if not PY2:
+            # in Python 3, python-memcached UTF8-decodes all strings before returning them
+            return rv.encode('utf8')
+        else:
+            return rv
 
     def _get_file(self, key, file):
         file.write(self._get(key))

--- a/tox.ini
+++ b/tox.ini
@@ -19,17 +19,3 @@ deps=
   dulwich
 commands=py.test -rs --pep8 --doctest-modules simplekv/idgen.py simplekv/fs.py tests
 
-# the environment below omits python-memcached, as that package does not even
-# install on py33
-[testenv:py33,py34]
-deps=
-  pytest
-  pytest-pep8
-  mock
-  tempdir
-  redis
-  psycopg2
-  sqlalchemy
-  pymysql
-  pymongo
-  dulwich


### PR DESCRIPTION
This makes the tests pass again on py33.

What caused the failing tests in the first place was the string handling in `python-memcached`. Since simplekv uses bytes for values (str in py2, bytes in py3), no conversion happens in `python-memcached`, values are stored unchanged as a string type. When objects are restored with py3, `python-memcached` always UTF-8-decodes strings (https://github.com/linsomniac/python-memcached/blob/master/memcache.py#L1257). 

This patch UTF-8-encodes values coming from `python-memcached`.