### PR TITLE
Improve compatibility with pylibmc, switch to pylibmc for tests

### DIFF
--- a/simplekv/memory/memcachestore.py
+++ b/simplekv/memory/memcachestore.py
@@ -18,7 +18,7 @@ class MemcacheStore(TimeToLiveMixin, KeyValueStore):
         self.mc = mc
 
     def _delete(self, key):
-        if not self.mc.delete(key.encode('ascii')):
+        if self.mc.delete(key.encode('ascii')) is 0:  # pylibmc's False is not an error
             raise IOError('Error deleting key')
 
     def _get(self, key):

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -7,7 +7,7 @@ from basic_store import BasicStore, TTLStore
 
 import pytest
 
-memcache = pytest.importorskip('memcache')
+memcache = pytest.importorskip('pylibmc')
 
 
 class TestMemcacheStore(TTLStore, BasicStore):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps=
   pytest-pep8
   mock
   tempdir
-  python-memcached
+  pylibmc
   redis
   psycopg2
   sqlalchemy


### PR DESCRIPTION
Currently, storing binary data with python-memcached on Python 3 is broken: https://github.com/linsomniac/python-memcached/issues/80

The purpose of this patch is to improve compatibility with pylibmc as an alternative memcached client, as well as to switch to pylibmc in the tests.

This pull request makes the tests pass again and should replace https://github.com/mbr/simplekv/pull/38

Details about the changes in memcachestore.py:
While pylibmc is meant as a drop-in replacement for python-memcached, there are some differences: http://sendapatch.se/projects/pylibmc/misc.html#differences-from-python-memcached

One place where this would cause a problem is key deletion when the key does not exist. This should not raise an exception in simplekv. python-memcached would always return `1`, whether the key existed or not, and return `0` in case of a serious error. pylibmc returns `True` if the key existed and was successfully deleted, and `False` if it doesn't exist and raises Exceptions for errors. 
simplekv generally doesn't hide differences in implementations, but the current check for the truth value of the return value of `client.delete()` would treat pylibmc's `False` (when the key does not exist) as an error, just like python-memcached's `0`. This patch only raises an error when the return value is `0`, but not for `False`.