### PR TITLE
Add prefix handling to keys() and iter_keys() API

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Changelog
 * The memcached backend has been removed
 * Keys have to be provided as unicode strings
 * Values have to be provided as bytes (python 2) or as str (python 3)
+* keys() and iter_keys() provide a parameter to iterate just over all keys with a given prefix
 
 0.10.0
 ======

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -110,7 +110,7 @@ class KeyValueStore(object):
 
     def keys(self, prefix=""):
         """Return a list of keys currently in store, in any order
-        If prefix is not the empty string, iterates only over all keys starting with prefix.
+        If prefix is not the empty string, returns only all keys starting with prefix.
 
         :raises exceptions.IOError: If there was an error accessing the store.
         """

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -99,20 +99,22 @@ class KeyValueStore(object):
         else:
             return self._get_file(key, file)
 
-    def iter_keys(self):
+    def iter_keys(self, prefix=""):
         """Return an Iterator over all keys currently in the store, in any
         order.
+        If prefix is not the empty string, iterates only over all keys starting with prefix.
 
         :raises exceptions.IOError: If there was an error accessing the store.
         """
         raise NotImplementedError
 
-    def keys(self):
+    def keys(self, prefix=""):
         """Return a list of keys currently in store, in any order
+        If prefix is not the empty string, iterates only over all keys starting with prefix.
 
         :raises exceptions.IOError: If there was an error accessing the store.
         """
-        return list(self.iter_keys())
+        return list(self.iter_keys(prefix))
 
     def open(self, key):
         """Open key for reading.

--- a/simplekv/_compat.py
+++ b/simplekv/_compat.py
@@ -23,8 +23,11 @@ else:
 
 if not PY2:
     imap = map
+    ifilter = filter
 else:
     from itertools import imap
+    from itertools import ifilter
+
 
 if not PY2:
     from io import BytesIO

--- a/simplekv/db/mongo.py
+++ b/simplekv/db/mongo.py
@@ -6,6 +6,7 @@ from .._compat import BytesIO
 
 from .._compat import pickle
 from bson.binary import Binary
+import re
 
 
 class MongoStore(KeyValueStore):
@@ -45,6 +46,6 @@ class MongoStore(KeyValueStore):
     def _put_file(self, key, file):
         return self._put(key, file.read())
 
-    def iter_keys(self):
-        for item in self.db[self.collection].find():
+    def iter_keys(self, prefix=""):
+        for item in self.db[self.collection].find({"_id": {"$regex": '^' + re.escape(prefix)}}):
             yield item["_id"]

--- a/simplekv/db/sql.py
+++ b/simplekv/db/sql.py
@@ -66,6 +66,6 @@ class SQLAlchemyStore(KeyValueStore):
     def iter_keys(self, prefix=""):
         query = select([self.table.c.key])
         if prefix != "":
-            query = query.filter(self.table.c.key.like(prefix + '%'))
+            query = query.where(self.table.c.key.like(prefix + '%'))
         return imap(lambda v: text_type(v[0]),
                     self.bind.execute(query))

--- a/simplekv/db/sql.py
+++ b/simplekv/db/sql.py
@@ -3,12 +3,10 @@
 
 from io import BytesIO
 
-from .._compat import text_type
-from .._compat import imap
+from .._compat import imap, text_type
 from .. import KeyValueStore
 
-from sqlalchemy import MetaData, Table, Column, String, LargeBinary, select,\
-                       delete, insert, update, exists
+from sqlalchemy import Table, Column, String, LargeBinary, select, exists
 
 
 class SQLAlchemyStore(KeyValueStore):
@@ -65,6 +63,9 @@ class SQLAlchemyStore(KeyValueStore):
     def _put_file(self, key, file):
         return self._put(key, file.read())
 
-    def iter_keys(self):
+    def iter_keys(self, prefix=""):
+        query = select([self.table.c.key])
+        if prefix != "":
+            query = query.filter(self.table.c.key.like(prefix + '%'))
         return imap(lambda v: text_type(v[0]),
-                   self.bind.execute(select([self.table.c.key])))
+                    self.bind.execute(query))

--- a/simplekv/decorator.py
+++ b/simplekv/decorator.py
@@ -29,6 +29,9 @@ class KeyTransformingDecorator(StoreDecorator):
     def _map_key(self, key):
         return key
 
+    def _map_key_prefix(self, key_prefix):
+        return key_prefix
+
     def _unmap_key(self, key):
         return key
 
@@ -50,16 +53,16 @@ class KeyTransformingDecorator(StoreDecorator):
     def get_file(self, key, *args, **kwargs):
         return self._dstore.get_file(self._map_key(key), *args, **kwargs)
 
-    def iter_keys(self):
-        return (self._unmap_key(k) for k in self._dstore.iter_keys()
+    def iter_keys(self, prefix=""):
+        return (self._unmap_key(k) for k in self._dstore.iter_keys(self._map_key_prefix(prefix))
                 if self._filter(k))
 
-    def keys(self):
+    def keys(self, prefix=""):
         """Return a list of keys currently in store, in any order
 
         :raises IOError: If there was an error accessing the store.
         """
-        return list(self.iter_keys())
+        return list(self.iter_keys(prefix))
 
     def open(self, key):
         return self._dstore.open(self._map_key(key))
@@ -95,6 +98,9 @@ class PrefixDecorator(KeyTransformingDecorator):
     def _map_key(self, key):
         self._check_valid_key(key)
         return self.prefix + key
+
+    def _map_key_prefix(self, key_prefix):
+        return self.prefix + key_prefix
 
     def _unmap_key(self, key):
         assert key.startswith(self.prefix)

--- a/simplekv/fs.py
+++ b/simplekv/fs.py
@@ -102,11 +102,11 @@ class FilesystemStore(KeyValueStore, UrlMixin):
         location = '/'.join(url_quote(p, safe='') for p in parts)
         return 'file://' + location
 
-    def keys(self):
-        return os.listdir(self.root)
+    def keys(self, prefix=""):
+        return filter(lambda p: p.startswith(prefix), os.listdir(self.root))
 
-    def iter_keys(self):
-        return iter(self.keys())
+    def iter_keys(self, prefix=""):
+        return iter(self.keys(prefix))
 
 
 class WebFilesystemStore(FilesystemStore):

--- a/simplekv/gae.py
+++ b/simplekv/gae.py
@@ -27,9 +27,9 @@ class NdbStore(KeyValueStore):
     def _has_key(self, key):
         return None != self.obj_class.get_by_id(id=key)
 
-    def iter_keys(self):
+    def iter_keys(self, prefix=""):
         qry_iter = self.obj_class.query().iter(keys_only=True)
-        return (k.string_id() for k in qry_iter)
+        return filter(lambda k: k.string_id().startswith(prefix), (k.string_id() for k in qry_iter))
 
     def _open(self, key):
         return StringIO(self._get(key))

--- a/simplekv/git.py
+++ b/simplekv/git.py
@@ -142,7 +142,7 @@ class GitCommitStore(KeyValueStore):
 
         return blob.data
 
-    def iter_keys(self):
+    def iter_keys(self, prefix=""):
         try:
             commit = self.repo[self._refname]
             tree = self.repo[commit.tree]
@@ -154,7 +154,8 @@ class GitCommitStore(KeyValueStore):
             pass
         else:
             for name in tree:
-                yield name.decode('ascii')
+                if name.decode('ascii').startswith(prefix):
+                    yield name.decode('ascii')
 
     def _open(self, key):
         return BytesIO(self._get(key))

--- a/simplekv/memory/__init__.py
+++ b/simplekv/memory/__init__.py
@@ -2,6 +2,7 @@
 # coding=utf8
 
 from io import BytesIO
+from .._compat import ifilter
 
 from .. import KeyValueStore
 
@@ -28,5 +29,5 @@ class DictStore(KeyValueStore):
         self.d[key] = file.read()
         return key
 
-    def iter_keys(self):
-        return iter(self.d)
+    def iter_keys(self, prefix=""):
+        return ifilter(lambda k: k.startswith(prefix), iter(self.d))

--- a/simplekv/memory/redisstore.py
+++ b/simplekv/memory/redisstore.py
@@ -4,7 +4,7 @@
 from io import BytesIO
 
 from .. import KeyValueStore, TimeToLiveMixin, NOT_SET, FOREVER
-
+import re
 
 class RedisStore(TimeToLiveMixin, KeyValueStore):
     """Uses a redis-database as the backend.
@@ -18,11 +18,11 @@ class RedisStore(TimeToLiveMixin, KeyValueStore):
     def _delete(self, key):
         return self.redis.delete(key)
 
-    def keys(self):
-        return list(map(lambda b: b.decode(), self.redis.keys()))
+    def keys(self, prefix=""):
+        return list(map(lambda b: b.decode(), self.redis.keys(pattern=re.escape(prefix) + '*')))
 
-    def iter_keys(self):
-        return iter(self.keys())
+    def iter_keys(self, prefix=""):
+        return iter(self.keys(prefix))
 
     def _has_key(self, key):
         return self.redis.exists(key)

--- a/simplekv/net/botostore.py
+++ b/simplekv/net/botostore.py
@@ -53,11 +53,11 @@ class BotoStore(KeyValueStore, UrlMixin):
 
         return d
 
-    def iter_keys(self):
+    def iter_keys(self, prefix=""):
         with map_boto_exceptions():
             prefix_len = len(self.prefix)
             return imap(lambda k: k.name[prefix_len:],
-                        self.bucket.list(self.prefix))
+                        self.bucket.list(self.prefix + prefix))
 
     def _has_key(self, key):
         with map_boto_exceptions(key=key):

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -168,6 +168,27 @@ class BasicStore(object):
 
         assert l == sorted([key, key2])
 
+    def test_key_iterator_with_prefix(self, store, key, key2, value):
+        prefix = key
+        key_prefix_1 = prefix + '_key1'
+        key_prefix_2 = prefix + '_key2'
+        store.put(key_prefix_1, value)
+        store.put(key_prefix_2, value)
+        store.put(key2, value)
+
+        l = []
+        for k in store.iter_keys():
+            l.append(k)
+        l.sort()
+
+        assert l == sorted([key_prefix_1, key_prefix_2, key2])
+
+        l = []
+        for k in store.iter_keys(prefix):
+            l.append(k)
+        l.sort()
+        assert l == sorted([key_prefix_1, key_prefix_2])
+
     def test_keys(self, store, key, key2, value, value2):
         store.put(key, value)
         store.put(key2, value2)
@@ -177,6 +198,20 @@ class BasicStore(object):
             assert isinstance(k, text_type)
 
         assert l == sorted([key, key2])
+
+    def test_keys_with_prefix(self, store, key, key2, value):
+        prefix = key
+        key_prefix_1 = prefix + '_key1'
+        key_prefix_2 = prefix + '_key2'
+        store.put(key_prefix_1, value)
+        store.put(key_prefix_2, value)
+        store.put(key2, value)
+
+        l = sorted(store.keys())
+        assert l == sorted([key_prefix_1, key_prefix_2, key2])
+
+        l = sorted(store.keys(prefix))
+        assert l == sorted([key_prefix_1, key_prefix_2])
 
     def test_has_key(self, store, key, key2, value):
         store.put(key, value)

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -177,7 +177,7 @@ class BasicStore(object):
         store.put(key2, value)
 
         l = []
-        for k in store.iter_keys():
+        for k in store.iter_keys(prefix):
             l.append(k)
         l.sort()
 

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -177,7 +177,7 @@ class BasicStore(object):
         store.put(key2, value)
 
         l = []
-        for k in store.iter_keys(prefix):
+        for k in store.iter_keys():
             l.append(k)
         l.sort()
 


### PR DESCRIPTION
Hi,

this PR adds prefix handling to the keys() and iter_keys() API.
When the user specifies a non-empty prefix, only keys starting with that prefix are returned.

This API is mainly useful when implementing/emulating file systems or other hierarchical structures on top of a KV store, as a prefix can be interpreted as a directory and the keys() call lists all "files" within such a directory.
Some backends implement this server-side, leading to increased efficiency, as we do not have to transfer all keys available from the backend to python and then filtering, but directly filtering on the server.
If there is no server-side filtering available, the filtering can be done in python, not leading to efficiency gains, but nonetheless being correct.

This depends on #39 for green tests.