### PR TITLE
Check type of data on put

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Changelog
 ======
 * The memcached backend has been removed
 * Keys have to be provided as unicode strings
+* Values have to be provided as bytes (python 2) or as str (python 3)
 
 0.10.0
 ======

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -143,6 +143,8 @@ class KeyValueStore(object):
                                     be read
         """
         self._check_valid_key(key)
+        if not isinstance(data, bytes):
+            raise IOError("Provided data is not of type bytes")
         return self._put(key, data)
 
     def put_file(self, key, file):

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -383,8 +383,13 @@ class TimeToLiveMixin(object):
            :param ttl_secs: Number of seconds until the key expires. See above
                             for valid values.
            :raises exceptions.ValueError: If ``ttl_secs`` is invalid.
+           :raises exceptions.IOError: If storing failed or the file could not
+                            be read
+
         """
         self._check_valid_key(key)
+        if not isinstance(data, bytes):
+            raise IOError("Provided data is not of type bytes")
         return self._put(key, data, self._valid_ttl(ttl_secs))
 
     def put_file(self, key, file, ttl_secs=None):

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -17,6 +17,10 @@ class BasicStore(object):
         key = store.put(key, value)
         assert isinstance(key, text_type)
 
+    def test_unicode_store(self, store, key, unicode_value):
+        with pytest.raises(IOError):
+            store.put(key, unicode_value)
+
     def test_store_and_retrieve(self, store, key, value):
         store.put(key, value)
         assert store.get(key) == value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,11 @@ def value2(request):
     return request.param
 
 
+@pytest.fixture(params=[u'the_other_value', u'othäöü_valਊਏਐਓਔਕਖਗue_2'])
+def unicode_value(request):
+    return request.param
+
+
 @pytest.fixture(params=[b'a_long_value' * 4 * 1024])
 def long_value(request):
     return request.param


### PR DESCRIPTION
Hi,

not all backends (at least not S3/boto) check that the data supplied in a put is of type bytes.
In S3, it is possible to store unicode data.
This leads to bugs in applications which are developed against S3 which switch backends later.
This PR checks the type and adds a test for this behauviour.

This depends on #39 for green tests.