### PR TITLE
Extended keyspace Mixin

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,6 @@ Changelog
 ======
 * The memcached backend has been removed
 * Keys have to be provided as unicode strings
-<<<<<<< HEAD
 * Values have to be provided as bytes (python 2) or as str (python 3)
 * keys() and iter_keys() provide a parameter to iterate just over all keys with a given prefix
 * Added :class:`simplekv.CopyMixin` to allow access to copy operations to
@@ -16,7 +15,8 @@ Changelog
   :class:`~simplekv.decorator.URLEncodeKeysDecorator`
 * Added a Microsoft Azure Blob Storage backend:
   :class:`~simplekv.net.azurestore.AzureBlockBlobStore`
-* Added :class:`~simplekv.ExtendedKeyspaceMixin` which allows slashes and spaces in key names
+* Added :class:`~simplekv.contrib.ExtendedKeyspaceMixin` which allows slashes and spaces in key names
+  This mixin is experimental, unsupported and might not work with all backends.
 
 
 0.10.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Changelog
 ======
 * The memcached backend has been removed
 * Keys have to be provided as unicode strings
+<<<<<<< HEAD
 * Values have to be provided as bytes (python 2) or as str (python 3)
 * keys() and iter_keys() provide a parameter to iterate just over all keys with a given prefix
 * Added :class:`simplekv.CopyMixin` to allow access to copy operations to
@@ -15,6 +16,7 @@ Changelog
   :class:`~simplekv.decorator.URLEncodeKeysDecorator`
 * Added a Microsoft Azure Blob Storage backend:
   :class:`~simplekv.net.azurestore.AzureBlockBlobStore`
+* Added :class:`~simplekv.ExtendedKeyspaceMixin` which allows slashes and spaces in key names
 
 
 0.10.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,6 +133,28 @@ this is represented by the :class:`~simplekv.TimeToLiveMixin`:
 
 .. _implement:
 
+
+Using slashes and spaces in key names
+=====================================
+Sometimes, the need arises for using slashes or spaces in key names, which is
+forbidden in simplekv as-is.
+To allow this use case, the :class:`~simplekv.ExtendedKeyspaceMixin` is provided.
+
+Use it like this (note that you have to derive from the mixin first!):
+::
+
+   class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, FilesystemStore):
+      pass
+   store = ExtendedKeyspaceStore(u'.')
+   store.put(u'/hi/this is a key', value)
+
+.. autoclass:: simplekv.ExtendedKeyspaceMixin
+
+.. autodata:: simplekv.VALID_KEY_REGEXP_EXTENDED
+
+.. autodata:: simplekv.VALID_KEY_RE_EXTENDED
+
+
 Implementing a new backend
 ==========================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,27 +134,6 @@ this is represented by the :class:`~simplekv.TimeToLiveMixin`:
 .. _implement:
 
 
-Using slashes and spaces in key names
-=====================================
-Sometimes, the need arises for using slashes or spaces in key names, which is
-forbidden in simplekv as-is.
-To allow this use case, the :class:`~simplekv.ExtendedKeyspaceMixin` is provided.
-
-Use it like this (note that you have to derive from the mixin first!):
-::
-
-   class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, FilesystemStore):
-      pass
-   store = ExtendedKeyspaceStore(u'.')
-   store.put(u'/hi/this is a key', value)
-
-.. autoclass:: simplekv.ExtendedKeyspaceMixin
-
-.. autodata:: simplekv.VALID_KEY_REGEXP_EXTENDED
-
-.. autodata:: simplekv.VALID_KEY_RE_EXTENDED
-
-
 Implementing a new backend
 ==========================
 

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -438,6 +438,7 @@ class UrlKeyValueStore(UrlMixin, KeyValueStore):
     """
     pass
 
+
 class CopyMixin(object):
     """Exposes a copy operation, if the backend supports it."""
 
@@ -455,7 +456,14 @@ class CopyMixin(object):
         self._check_valid_key(dest)
         return self._copy(source, dest)
 
+
 class ExtendedKeyspaceMixin(object):
+    """A mixin to extend the keyspace to allow slashes and spaces in keynames.
+    
+    Attention: A single / is NOT allowed.
+    Use it by extending first from ` :class:`~simplekv.ExtendedKeyspaceMixin`
+    and then by the desired store.
+    """
     def _check_valid_key(self, key):
         """Checks if a key is valid and raises a ValueError if its not.
 
@@ -464,5 +472,7 @@ class ExtendedKeyspaceMixin(object):
 
         :param key: The key to be checked
         """
-        if not VALID_KEY_RE_EXTENDED.match(key):
+        if not isinstance(key, text_type) and key is not None:
+            raise ValueError('%r is not a unicode string' % key)
+        if not VALID_KEY_RE_EXTENDED.match(key) or key == u'/':
             raise ValueError('%r contains illegal characters' % key)

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -8,20 +8,13 @@ from ._compat import text_type
 __version__ = '0.11.0.dev1'
 
 VALID_NON_NUM = r"""\`\!"#$%&'()+,-.<=>?@[]^_{}~"""
-VALID_NON_NUM_EXTENDED = VALID_NON_NUM + r"/ "
 VALID_KEY_REGEXP = "^[%s0-9a-zA-Z]+$" % re.escape(VALID_NON_NUM)
 """This regular expression tests if a key is valid. Allowed are all
 alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~``."""
 
-VALID_KEY_REGEXP_EXTENDED = "^[%s0-9a-zA-Z]+$" % re.escape(VALID_NON_NUM_EXTENDED)
-"""This regular expression tests if a key is valid when the extended keyspace mixin is used. Allowed are all
-alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~/``. and spaces"""
-
-
 VALID_KEY_RE = re.compile(VALID_KEY_REGEXP)
 """A compiled version of :data:`~simplekv.VALID_KEY_REGEXP`."""
-VALID_KEY_RE_EXTENDED = re.compile(VALID_KEY_REGEXP_EXTENDED)
-"""A compiled version of :data:`~simplekv.VALID_KEY_REGEXP_EXTENDED`."""
+
 
 class KeyValueStore(object):
     """The smallest API supported by all backends.
@@ -455,24 +448,3 @@ class CopyMixin(object):
         self._check_valid_key(source)
         self._check_valid_key(dest)
         return self._copy(source, dest)
-
-
-class ExtendedKeyspaceMixin(object):
-    """A mixin to extend the keyspace to allow slashes and spaces in keynames.
-    
-    Attention: A single / is NOT allowed.
-    Use it by extending first from ` :class:`~simplekv.ExtendedKeyspaceMixin`
-    and then by the desired store.
-    """
-    def _check_valid_key(self, key):
-        """Checks if a key is valid and raises a ValueError if its not.
-
-        When in need of checking a key for validity, always use this
-        method if possible.
-
-        :param key: The key to be checked
-        """
-        if not isinstance(key, text_type) and key is not None:
-            raise ValueError('%r is not a unicode string' % key)
-        if not VALID_KEY_RE_EXTENDED.match(key) or key == u'/':
-            raise ValueError('%r contains illegal characters' % key)

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -8,13 +8,20 @@ from ._compat import text_type
 __version__ = '0.11.0.dev1'
 
 VALID_NON_NUM = r"""\`\!"#$%&'()+,-.<=>?@[]^_{}~"""
+VALID_NON_NUM_EXTENDED = VALID_NON_NUM + r"/ "
 VALID_KEY_REGEXP = "^[%s0-9a-zA-Z]+$" % re.escape(VALID_NON_NUM)
 """This regular expression tests if a key is valid. Allowed are all
 alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~``."""
 
+VALID_KEY_REGEXP_EXTENDED = "^[%s0-9a-zA-Z]+$" % re.escape(VALID_NON_NUM_EXTENDED)
+"""This regular expression tests if a key is valid when the extended keyspace mixin is used. Allowed are all
+alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~/``. and spaces"""
+
+
 VALID_KEY_RE = re.compile(VALID_KEY_REGEXP)
 """A compiled version of :data:`~simplekv.VALID_KEY_REGEXP`."""
-
+VALID_KEY_RE_EXTENDED = re.compile(VALID_KEY_REGEXP_EXTENDED)
+"""A compiled version of :data:`~simplekv.VALID_KEY_REGEXP_EXTENDED`."""
 
 class KeyValueStore(object):
     """The smallest API supported by all backends.
@@ -431,7 +438,6 @@ class UrlKeyValueStore(UrlMixin, KeyValueStore):
     """
     pass
 
-
 class CopyMixin(object):
     """Exposes a copy operation, if the backend supports it."""
 
@@ -448,3 +454,15 @@ class CopyMixin(object):
         self._check_valid_key(source)
         self._check_valid_key(dest)
         return self._copy(source, dest)
+
+class ExtendedKeyspaceMixin(object):
+    def _check_valid_key(self, key):
+        """Checks if a key is valid and raises a ValueError if its not.
+
+        When in need of checking a key for validity, always use this
+        method if possible.
+
+        :param key: The key to be checked
+        """
+        if not VALID_KEY_RE_EXTENDED.match(key):
+            raise ValueError('%r contains illegal characters' % key)

--- a/simplekv/contrib/__init__.py
+++ b/simplekv/contrib/__init__.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# coding=utf8
+import re
+
+from simplekv import VALID_NON_NUM
+from simplekv._compat import text_type
+
+VALID_NON_NUM_EXTENDED = VALID_NON_NUM + r"/ "
+VALID_KEY_REGEXP_EXTENDED = "^[%s0-9a-zA-Z]+$" % re.escape(VALID_NON_NUM_EXTENDED)
+"""This regular expression tests if a key is valid when the extended keyspace mixin is used. Allowed are all
+alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~/``. and spaces"""
+VALID_KEY_RE_EXTENDED = re.compile(VALID_KEY_REGEXP_EXTENDED)
+"""A compiled version of :data:`~simplekv.VALID_KEY_REGEXP_EXTENDED`."""
+
+
+class ExtendedKeyspaceMixin(object):
+    """A mixin to extend the keyspace to allow slashes and spaces in keynames.
+
+    Attention: A single / is NOT allowed.
+    Use it by extending first from ` :class:`~simplekv.ExtendedKeyspaceMixin`
+    and then by the desired store.
+    Note: This Mixin is unsupported and might not work correctly with all backends.
+    """
+    def _check_valid_key(self, key):
+        """Checks if a key is valid and raises a ValueError if its not.
+
+        When in need of checking a key for validity, always use this
+        method if possible.
+
+        :param key: The key to be checked
+        """
+        if not isinstance(key, text_type) and key is not None:
+            raise ValueError('%r is not a unicode string' % key)
+        if not VALID_KEY_RE_EXTENDED.match(key) or key == u'/':
+            raise ValueError('%r contains illegal characters' % key)

--- a/simplekv/fs.py
+++ b/simplekv/fs.py
@@ -137,8 +137,9 @@ class FilesystemStore(KeyValueStore, UrlMixin, CopyMixin):
 
     def keys(self, prefix=u""):
         root = os.path.abspath(self.root)
-        return filter(lambda p: p.startswith(prefix), [os.path.join(dp, f)[len(root)+1:]
-                for dp, dn, fn in os.walk(root) for f in fn])
+        return filter(lambda p: p.startswith(prefix),
+                      [os.path.join(dp, f)[len(root)+1:]
+                      for dp, dn, fn in os.walk(root) for f in fn])
 
     def iter_keys(self, prefix=u""):
         return iter(self.keys(prefix))

--- a/simplekv/fs.py
+++ b/simplekv/fs.py
@@ -87,6 +87,7 @@ class FilesystemStore(KeyValueStore, UrlMixin, CopyMixin):
             source_file_name = self._build_filename(source)
             dest_file_name = self._build_filename(dest)
 
+            self._ensure_dir_exists(os.path.dirname(dest_file_name))
             shutil.copy(source_file_name, dest_file_name)
             self._fix_permissions(dest_file_name)
             return dest

--- a/simplekv/git.py
+++ b/simplekv/git.py
@@ -162,7 +162,7 @@ class GitCommitStore(KeyValueStore):
                     .iter_tree_contents(tree.sha().hexdigest()):
                 print(o.path)
                 if o.path.startswith(prefix):
-                    yield text_type(o.path)
+                    yield text_type(o.path.decode('ascii'))
 
     def _open(self, key):
         return BytesIO(self._get(key))

--- a/simplekv/git.py
+++ b/simplekv/git.py
@@ -159,10 +159,9 @@ class GitCommitStore(KeyValueStore):
             pass
         else:
             for o in self.repo.object_store\
-                    .iter_tree_contents(tree.sha().hexdigest()):
-                print(o.path)
-                if o.path.startswith(prefix):
-                    yield text_type(o.path.decode('ascii'))
+                    .iter_tree_contents(tree.sha().hexdigest().encode('ascii')):
+                if o.path.decode('ascii').startswith(prefix):
+                    yield o.path.decode('ascii')
 
     def _open(self, key):
         return BytesIO(self._get(key))

--- a/simplekv/git.py
+++ b/simplekv/git.py
@@ -6,6 +6,7 @@ from dulwich.repo import Repo
 from dulwich.objects import Commit, Tree, Blob
 
 from . import KeyValueStore, __version__
+from ._compat import text_type
 
 
 def _on_tree(repo, tree, components, obj):
@@ -77,6 +78,10 @@ class GitCommitStore(KeyValueStore):
     def _subdir_components(self):
         return [c.encode('ascii') for c in self.subdir.split('/')]
 
+    def _key_components(self, key):
+        return [c.encode('ascii') for c in key.split('/')]
+
+
     @property
     def _refname(self):
         return b'refs/heads/' + self.branch
@@ -109,7 +114,7 @@ class GitCommitStore(KeyValueStore):
         commit = self._create_top_commit()
         objects_to_add = []
 
-        components = [key.encode('ascii')]
+        components = self._key_components(key)
         if self.subdir:
             components = self._subdir_components + components
 
@@ -153,9 +158,11 @@ class GitCommitStore(KeyValueStore):
         except KeyError:
             pass
         else:
-            for name in tree:
-                if name.decode('ascii').startswith(prefix):
-                    yield name.decode('ascii')
+            for o in self.repo.object_store\
+                    .iter_tree_contents(tree.sha().hexdigest()):
+                print(o.path)
+                if o.path.startswith(prefix):
+                    yield text_type(o.path)
 
     def _open(self, key):
         return BytesIO(self._get(key))
@@ -183,8 +190,7 @@ class GitCommitStore(KeyValueStore):
 
         objects_to_add = [blob]
 
-        # no subdirs in filename, add directly to tree
-        components = [key.encode('ascii')]
+        components = self._key_components(key)
         if self.subdir:
             components = self._subdir_components + components
         res = _on_tree(self.repo, tree, components, blob)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,3 +63,20 @@ def bytestring_key(request):
 @pytest.fixture(params=[u'a' * 250, u'b' * 250])
 def max_key(request):
     return request.param
+
+
+# Test class to derive from to get test fixtures for the extended keyspace
+class ExtendedKeyspaceTests:
+    @pytest.fixture(params=[u'short ke/y', u'short_key', u'spaces  in key',
+                            u"""'!"`#$%&'()+,-.<=>?@[]^_{}~/'"""])
+    def key(self, request):
+        return request.param
+
+    @pytest.fixture(params=[u'key_number/2 with space',
+                            u'and_again_a_second_key'])
+    def key2(self, request):
+        return request.param
+
+    @pytest.fixture(params=[u'ä', u'/', u'\x00', u'*', u''])
+    def invalid_key(self, request):
+        return request.param

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -1,7 +1,9 @@
 from uuid import uuid4 as uuid
 from simplekv._compat import ConfigParser, pickle
 from simplekv.net.azurestore import AzureBlockBlobStore
+from simplekv.contrib import ExtendedKeyspaceMixin
 from basic_store import BasicStore
+from conftest import ExtendedKeyspaceTests
 import pytest
 
 pytest.importorskip('azure.storage')
@@ -45,6 +47,22 @@ class TestAzureStorage(BasicStore):
 
         yield AzureBlockBlobStore(conn_string=conn_string, container=container,
                                   public=False)
+        s.delete_container(container)
+
+
+class TestExtendedKeyspaceAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, AzureBlockBlobStore):
+            pass
+        from azure.storage.blob import BlockBlobService
+
+        container = uuid()
+        conn_string = create_azure_conn_string(load_azure_credentials())
+        s = BlockBlobService(connection_string=conn_string)
+
+        yield ExtendedKeyspaceStore(conn_string=conn_string,
+                                    container=container, public=False)
         s.delete_container(container)
 
 

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -50,10 +50,10 @@ class TestAzureStorage(BasicStore):
         s.delete_container(container)
 
 
-class TestExtendedKeyspaceAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
+class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
     @pytest.fixture
     def store(self):
-        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, AzureBlockBlobStore):
+        class ExtendedKeysStore(ExtendedKeyspaceMixin, AzureBlockBlobStore):
             pass
         from azure.storage.blob import BlockBlobService
 
@@ -61,8 +61,8 @@ class TestExtendedKeyspaceAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
         conn_string = create_azure_conn_string(load_azure_credentials())
         s = BlockBlobService(connection_string=conn_string)
 
-        yield ExtendedKeyspaceStore(conn_string=conn_string,
-                                    container=container, public=False)
+        yield ExtendedKeysStore(conn_string=conn_string,
+                                container=container, public=False)
         s.delete_container(container)
 
 

--- a/tests/test_boto_store.py
+++ b/tests/test_boto_store.py
@@ -12,6 +12,8 @@ from simplekv._compat import BytesIO
 from basic_store import BasicStore
 from url_store import UrlStore
 from bucket_manager import boto_credentials, boto_bucket
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
 
 
 @pytest.fixture(params=boto_credentials,
@@ -81,3 +83,12 @@ class TestBotoStorage(BasicStore, UrlStore):
         if storage_class != 'STANDARD':
             pytest.xfail('boto does not support checking the storage class?')
         assert bucket.lookup(keyname).storage_class == storage_class
+
+
+class TestExtendedKeyspaceBotoStore(TestBotoStorage, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self, bucket, prefix, reduced_redundancy):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, BotoStore):
+            pass
+        return ExtendedKeyspaceStore(bucket, prefix,
+                                     reduced_redundancy=reduced_redundancy)

--- a/tests/test_boto_store.py
+++ b/tests/test_boto_store.py
@@ -13,7 +13,7 @@ from basic_store import BasicStore
 from url_store import UrlStore
 from bucket_manager import boto_credentials, boto_bucket
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 
 @pytest.fixture(params=boto_credentials,

--- a/tests/test_dict_store.py
+++ b/tests/test_dict_store.py
@@ -7,7 +7,7 @@ from test_hmac import HMACDec
 
 import pytest
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 
 class TestDictStore(BasicStore, UUIDGen, HashGen, HMACDec):

--- a/tests/test_dict_store.py
+++ b/tests/test_dict_store.py
@@ -6,9 +6,19 @@ from idgens import UUIDGen, HashGen
 from test_hmac import HMACDec
 
 import pytest
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
 
 
 class TestDictStore(BasicStore, UUIDGen, HashGen, HMACDec):
     @pytest.fixture
     def store(self):
         return DictStore()
+
+
+class TestExtendedKeyspaceDictStore(TestDictStore, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, DictStore):
+            pass
+        return ExtendedKeyspaceStore()

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -13,6 +13,9 @@ from basic_store import BasicStore
 from url_store import UrlStore
 from idgens import UUIDGen, HashGen
 
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
+
 from mock import Mock
 import pytest
 
@@ -139,3 +142,12 @@ class TestWebFileStore(TestBaseFilesystemStore):
         assert store.url_for(key) == expected
 
         mock_callable.assert_called_with(store, key)
+
+
+class TestExtendedKeyspaceFilesystemStore(TestBaseFilesystemStore,
+                                          ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self, tmpdir):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, FilesystemStore):
+            pass
+        return ExtendedKeyspaceStore(tmpdir)

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -14,7 +14,7 @@ from url_store import UrlStore
 from idgens import UUIDGen, HashGen
 
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 from mock import Mock
 import pytest

--- a/tests/test_git_store.py
+++ b/tests/test_git_store.py
@@ -7,7 +7,7 @@ import pytest
 from simplekv.git import GitCommitStore
 
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 
 class TestGitCommitStore(BasicStore, UUIDGen, HashGen):

--- a/tests/test_git_store.py
+++ b/tests/test_git_store.py
@@ -6,13 +6,16 @@ import pytest
 
 from simplekv.git import GitCommitStore
 
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
+
 
 class TestGitCommitStore(BasicStore, UUIDGen, HashGen):
-    @pytest.fixture(params=[b'master', b'not-master', b'other-branch'])
+    @pytest.fixture(params=[b'master', b'not-master'])
     def branch(self, request):
         return request.param
 
-    @pytest.fixture(params=[b'', b'/', b'subdir', b'subdir/', b'sub/subdir/',
+    @pytest.fixture(params=[b'', b'/', b'subdir', b'sub/subdir/',
                             b'/sub/subdir', b'/sub/subdir/'])
     def subdir_name(self, request):
         return request.param
@@ -63,3 +66,13 @@ class TestGitCommitStore(BasicStore, UUIDGen, HashGen):
             fn2 = sdir + '/' + fn2
         _, blob_id = tree.lookup_path(repo.__getitem__, fn2.encode('ascii'))
         assert repo[blob_id].data == b'bar2'
+
+
+class TestExtendedKeyspaceGitStore(TestGitCommitStore,
+                                   ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self, repo_path, branch, subdir_name):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, GitCommitStore):
+            pass
+        return ExtendedKeyspaceStore(repo_path, branch=branch,
+                                     subdir=subdir_name)

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -9,7 +9,7 @@ pymongo = pytest.importorskip('pymongo')
 from simplekv.db.mongo import MongoStore
 from basic_store import BasicStore
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 
 class TestMongoDB(BasicStore):

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -8,6 +8,8 @@ pymongo = pytest.importorskip('pymongo')
 
 from simplekv.db.mongo import MongoStore
 from basic_store import BasicStore
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
 
 
 class TestMongoDB(BasicStore):
@@ -22,4 +24,17 @@ class TestMongoDB(BasicStore):
         except pymongo.errors.ConnectionFailure:
             pytest.skip('could not connect to mongodb')
         yield MongoStore(conn[db_name], 'simplekv-tests')
+        conn.drop_database(db_name)
+
+
+class TestExtendedKeyspaceDictStore(TestMongoDB, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self, db_name):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, MongoStore):
+            pass
+        try:
+            conn = pymongo.MongoClient()
+        except pymongo.errors.ConnectionFailure:
+            pytest.skip('could not connect to mongodb')
+        yield ExtendedKeyspaceStore(conn[db_name], 'simplekv-tests')
         conn.drop_database(db_name)

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -2,7 +2,7 @@
 
 from basic_store import BasicStore, TTLStore
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 import pytest
 redis = pytest.importorskip('redis')

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 from basic_store import BasicStore, TTLStore
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
 
 import pytest
 redis = pytest.importorskip('redis')
@@ -22,4 +24,23 @@ class TestRedisStore(TTLStore, BasicStore):
 
         r.flushdb()
         yield RedisStore(r)
+        r.flushdb()
+
+
+class TestExtendedKeyspaceDictStore(TestRedisStore, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self):
+        from simplekv.memory.redisstore import RedisStore
+
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, RedisStore):
+            pass
+        r = StrictRedis()
+
+        try:
+            r.get('anything')
+        except ConnectionError:
+            pytest.skip('Could not connect to redis server')
+
+        r.flushdb()
+        yield ExtendedKeyspaceStore(r)
         r.flushdb()

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -11,7 +11,7 @@ from simplekv.db.sql import SQLAlchemyStore
 
 from basic_store import BasicStore
 from conftest import ExtendedKeyspaceTests
-from simplekv import ExtendedKeyspaceMixin
+from simplekv.contrib import ExtendedKeyspaceMixin
 
 
 # FIXME: for local testing, this needs configurable dsns

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -47,7 +47,8 @@ class TestSQLAlchemyStore(BasicStore):
         metadata.drop_all()
 
 
-class TestExtendedKeyspaceDictStore(TestSQLAlchemyStore, ExtendedKeyspaceTests):
+class TestExtendedKeyspaceSQLAlchemyStore(TestSQLAlchemyStore,
+                                          ExtendedKeyspaceTests):
     @pytest.fixture
     def store(self, engine):
         class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, SQLAlchemyStore):

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -10,6 +10,8 @@ from sqlalchemy.exc import OperationalError
 from simplekv.db.sql import SQLAlchemyStore
 
 from basic_store import BasicStore
+from conftest import ExtendedKeyspaceTests
+from simplekv import ExtendedKeyspaceMixin
 
 
 # FIXME: for local testing, this needs configurable dsns
@@ -39,10 +41,20 @@ class TestSQLAlchemyStore(BasicStore):
     def store(self, engine):
         metadata = MetaData(bind=engine)
         store = SQLAlchemyStore(engine, metadata, 'simplekv_test')
-
         # create table
         store.table.create()
-
         yield store
+        metadata.drop_all()
 
+
+class TestExtendedKeyspaceDictStore(TestSQLAlchemyStore, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self, engine):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, SQLAlchemyStore):
+            pass
+        metadata = MetaData(bind=engine)
+        store = ExtendedKeyspaceStore(engine, metadata, 'simplekv_test')
+        # create table
+        store.table.create()
+        yield store
         metadata.drop_all()


### PR DESCRIPTION
Hi,

this pull request provides a mixin for an extended keyspace, allowing both spaces and slashes in paths.
Using this mixin is optional. Supporting slashes required some work in the filesystem and in the git backend, all other backends handle these keys transparently anyways.