### PR TITLE
Make botostore importable without boto module

### DIFF
--- a/simplekv/net/botostore.py
+++ b/simplekv/net/botostore.py
@@ -2,12 +2,24 @@
 # coding=utf8
 
 from .._compat import imap
-
-from boto.exception import BotoClientError, BotoServerError,\
-                           StorageResponseError
-from boto.s3.key import Key
-
 from .. import KeyValueStore, UrlMixin
+from contextlib import contextmanager
+
+
+@contextmanager
+def map_boto_exceptions(key=None, exc_pass=()):
+    """Map boto-specific exceptions to the simplekv-API."""
+    from boto.exception import BotoClientError, BotoServerError, \
+        StorageResponseError
+    try:
+        yield
+    except StorageResponseError as e:
+        if e.code == 'NoSuchKey':
+            raise KeyError(key)
+        raise IOError(str(e))
+    except (BotoClientError, BotoServerError) as e:
+        if ex.__class__.__name__ not in exc_pass:
+            raise IOError(str(e))
 
 
 class BotoStore(KeyValueStore, UrlMixin):
@@ -21,6 +33,8 @@ class BotoStore(KeyValueStore, UrlMixin):
         self.metadata = metadata or {}
 
     def __new_key(self, name):
+        from boto.s3.key import Key
+
         k = Key(self.bucket, self.prefix + name)
         if self.metadata:
             k.update_metadata(self.metadata)
@@ -40,20 +54,17 @@ class BotoStore(KeyValueStore, UrlMixin):
         return d
 
     def iter_keys(self):
-        try:
+        with map_boto_exceptions():
             prefix_len = len(self.prefix)
             return imap(lambda k: k.name[prefix_len:],
                         self.bucket.list(self.prefix))
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _has_key(self, key):
-        try:
+        with map_boto_exceptions(key=key):
             return bool(self.bucket.get_key(self.prefix + key))
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _delete(self, key):
+        from boto.exception import StorageResponseError
         try:
             self.bucket.delete_key(self.prefix + key)
         except StorageResponseError as e:
@@ -62,83 +73,51 @@ class BotoStore(KeyValueStore, UrlMixin):
 
     def _get(self, key):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             return k.get_contents_as_string()
-        except StorageResponseError as e:
-            if e.code == 'NoSuchKey':
-                raise KeyError(key)
-            raise IOError(str(e))
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _get_file(self, key, file):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             return k.get_contents_to_file(file)
-        except StorageResponseError as e:
-            if e.code == 'NoSuchKey':
-                raise KeyError(key)
-            raise IOError(str(e))
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _get_filename(self, key, filename):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             return k.get_contents_to_filename(filename)
-        except StorageResponseError as e:
-            if e.code == 'NoSuchKey':
-                raise KeyError(key)
-            raise IOError(str(e))
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _open(self, key):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             k.open_read()
             return k
-        except StorageResponseError as e:
-            if e.code == 'NoSuchKey':
-                raise KeyError(key)
-            raise IOError(str(e))
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _put(self, key, data):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             k.set_contents_from_string(
                 data, **self.__upload_args()
             )
             return key
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _put_file(self, key, file):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             k.set_contents_from_file(
                 file, **self.__upload_args()
             )
             return key
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _put_filename(self, key, filename):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             k.set_contents_from_filename(
                 filename, **self.__upload_args()
             )
             return key
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))
 
     def _url_for(self, key):
         k = self.__new_key(key)
-        try:
+        with map_boto_exceptions(key=key):
             return k.generate_url(expires_in=self.url_valid_time,
                                   query_auth=False)
-        except (BotoClientError, BotoServerError) as e:
-            raise IOError(str(e))


### PR DESCRIPTION
Hi,

this makes the boto store importable without the boto module being present by moving the imports down enough.

Obviously, the boto store can't be actually used if the boto module is not present.