### PR TITLE
Add common base class for KeyValueStore and StoreDecorator

### DIFF
--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -16,7 +16,16 @@ VALID_KEY_RE = re.compile(VALID_KEY_REGEXP)
 """A compiled version of :data:`~simplekv.VALID_KEY_REGEXP`."""
 
 
-class KeyValueStore(object):
+class KeyValueStoreBase(object):
+    """Base class for everything that fulfills the KeyValueStore API
+
+    Actual stores have to be subclassed from either :class:`KeyValueStore` or
+    :class:`StoreDecorator`. This class serves as a common ancestor, but contains
+    no implementation or interface definition.
+    """
+
+
+class KeyValueStore(KeyValueStoreBase):
     """The smallest API supported by all backends.
 
     Keys are ascii-strings with certain restrictions, guaranteed to be properly

--- a/simplekv/decorator.py
+++ b/simplekv/decorator.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # coding=utf8
 from ._compat import quote_plus, unquote_plus, text_type, binary_type
+from . import KeyValueStoreBase
 
 
-class StoreDecorator(object):
+class StoreDecorator(KeyValueStoreBase):
     """Base class for store decorators.
 
     The default implementation will use :func:`getattr` to pass through all


### PR DESCRIPTION
I propose to introduce a common base class for `KeyValueStore` and `StoreDecorator` in order to make it simpler to check for the __simplekv core API__.

Right now, `StoreDecorator`-based instances are not sub classes of `KeyValueStore` or a common base class. So in order to check if something can be considered a `KeyValueStore`, you would have to check if it is an instance of either `KeyValueStore` or `StoreDecorator`.

The purpose would be purely to signal that the API is implemented, but not to enforce it. That means that the base class would be empty, and implementations would need to still subclass either `KeyValueStore` or `StoreDecorator`. That way, `StoreDecorator` would keep its minimal, `__getattr__()`-based signature.