### PR TITLE
Use basestring to check for key validity in Python 2

### DIFF
--- a/simplekv/_compat.py
+++ b/simplekv/_compat.py
@@ -54,6 +54,6 @@ if not PY2:
     unichr = chr
     binary_type = bytes
 else:
-    text_type = unicode
+    text_type = basestring
     unichr = unichr
     binary_type = str


### PR DESCRIPTION
Fixes #57 