### PR TITLE
add key_type definition, check keys against key_type

### DIFF
--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -3,7 +3,7 @@
 
 import re
 from io import BytesIO
-from ._compat import text_type
+from ._compat import key_type
 
 __version__ = '0.11.1'
 
@@ -186,7 +186,7 @@ class KeyValueStore(object):
 
         :param key: The key to be checked
         """
-        if not isinstance(key, text_type):
+        if not isinstance(key, key_type):
             raise ValueError('%r is not a unicode string' % key)
         if not VALID_KEY_RE.match(key):
             raise ValueError('%r contains illegal characters' % key)

--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -187,7 +187,7 @@ class KeyValueStore(object):
         :param key: The key to be checked
         """
         if not isinstance(key, key_type):
-            raise ValueError('%r is not a unicode string' % key)
+            raise ValueError('%r is not a valid key type' % key)
         if not VALID_KEY_RE.match(key):
             raise ValueError('%r contains illegal characters' % key)
 

--- a/simplekv/_compat.py
+++ b/simplekv/_compat.py
@@ -51,9 +51,11 @@ xrange = range if not PY2 else xrange
 
 if not PY2:
     text_type = str
+    key_type = str
     unichr = chr
     binary_type = bytes
 else:
     text_type = unicode
+    key_type = basestring
     unichr = unichr
     binary_type = str

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -69,10 +69,6 @@ class BasicStore(object):
         assert long_value[3:5] == ok.read(2)
         assert long_value[5:8] == ok.read(3)
 
-    def test_bytestring_key_store(self, store, bytestring_key, value):
-        with pytest.raises(ValueError):
-            store.put(bytestring_key, value)
-
     def test_key_error_on_nonexistant_get(self, store, key):
         with pytest.raises(KeyError):
             store.get(key)


### PR DESCRIPTION
This is intended to fix #57, by adding a Python-version-dependent definition for valid classes for keys.