### PR TITLE
Azure Backend: Implement open() which supports partial reads

### DIFF
--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -148,7 +148,7 @@ class IOInterface(io.BufferedIOBase):
         """Returns 'size' amount of bytes or less if there is no more data.
         If no size is given all data is returned. size can be >= 0."""
         with map_azure_exceptions(key=self.key):
-            if size <0:
+            if size < 0:
                 size = self.size - self.pos
 
             #TODO double check +/- 1

--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -149,6 +149,8 @@ class IOInterface(io.BufferedIOBase):
                 size = self.size - self.pos
 
             end = min(self.pos + size - 1, self.size)
+            if self.pos > end:
+                return b''
             b = self.block_blob_service.get_blob_to_bytes(
                     self.container_name,
                     self.key,
@@ -180,3 +182,6 @@ class IOInterface(io.BufferedIOBase):
             if self.size + offset < 0:
                 raise IOError('seek would move position outside the file')
             self.pos = self.size + offset
+
+    def seekable(self):
+        return True

--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -151,13 +151,12 @@ class IOInterface(io.BufferedIOBase):
             if size < 0:
                 size = self.size - self.pos
 
-            #TODO double check +/- 1
-            end = min(self.pos+size-1, self.size)
+            end = min(self.pos + size - 1, self.size)
             b = self.block_blob_service.get_blob_to_bytes(self.container_name,
                                                           self.key,
                                                           start_range=self.pos,
                                                           end_range=end)  # end_range is inclusive
-            self.pos += end+1
+            self.pos += end + 1
             return b.content
 
     def seek(self, offset, whence=0):

--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -89,11 +89,8 @@ class AzureBlockBlobStore(KeyValueStore):
 
     def _put(self, key, data):
         with map_azure_exceptions(key=key):
-            if isinstance(data, binary_type):
-                self.block_blob_service.create_blob_from_bytes(self.container,
+            self.block_blob_service.create_blob_from_bytes(self.container,
                                                                key, data)
-            else:
-                raise TypeError('Wrong type, expecting str or bytes.')
             return key
 
     def _put_file(self, key, file):

--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -152,11 +152,12 @@ class IOInterface(io.BufferedIOBase):
                 size = self.size - self.pos
 
             end = min(self.pos + size - 1, self.size)
-            b = self.block_blob_service.get_blob_to_bytes(self.container_name,
-                                                          self.key,
-                                                          start_range=self.pos,
-                                                          end_range=end)  # end_range is inclusive
-            self.pos += end + 1
+            b = self.block_blob_service.get_blob_to_bytes(
+                    self.container_name,
+                    self.key,
+                    start_range=self.pos,
+                    end_range=end)  # end_range is inclusive
+            self.pos += len(b.content)
             return b.content
 
     def seek(self, offset, whence=0):
@@ -171,8 +172,14 @@ class IOInterface(io.BufferedIOBase):
         should succeed. tell() should report that position and read()
         should return an empty bytes object."""
         if whence == 0:
+            if offset < 0:
+                raise IOError('seek would move position outside the file')
             self.pos = offset
         elif whence == 1:
+            if self.pos + offset < 0:
+                raise IOError('seek would move position outside the file')
             self.pos += offset
         elif whence == 2:
+            if self.size + offset < 0:
+                raise IOError('seek would move position outside the file')
             self.pos = self.size + offset

--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -85,11 +85,7 @@ class AzureBlockBlobStore(KeyValueStore):
 
     def _open(self, key):
         with map_azure_exceptions(key=key):
-            output_stream = io.BytesIO()
-            self.block_blob_service.get_blob_to_stream(self.container, key,
-                                                       output_stream)
-            output_stream.seek(0)
-            return output_stream
+            return IOInterface(self.block_blob_service, self.container, key)
 
     def _put(self, key, data):
         with map_azure_exceptions(key=key):
@@ -128,3 +124,56 @@ def pickle_azure_store(store):
                              store.create_if_missing)
 
 copyreg.pickle(AzureBlockBlobStore, pickle_azure_store)
+
+
+class IOInterface(io.BufferedIOBase):
+    """
+    Class which provides a file-like interface to selectively read from a blob in the blob store.
+    """
+    def __init__(self, block_blob_service, container_name, key):
+        super(IOInterface, self).__init__()
+        self.block_blob_service = block_blob_service
+        self.container_name = container_name
+        self.key = key
+
+        blob = self.block_blob_service.get_blob_properties(container_name, key)
+        self.size = blob.properties.content_length
+        self.pos = 0
+
+    def tell(self):
+        """Returns he current offset as int. Always >= 0."""
+        return self.pos
+
+    def read(self, size=-1):
+        """Returns 'size' amount of bytes or less if there is no more data.
+        If no size is given all data is returned. size can be >= 0."""
+        with map_azure_exceptions(key=self.key):
+            if size <0:
+                size = self.size - self.pos
+
+            #TODO double check +/- 1
+            end = min(self.pos+size-1, self.size)
+            b = self.block_blob_service.get_blob_to_bytes(self.container_name,
+                                                          self.key,
+                                                          start_range=self.pos,
+                                                          end_range=end)  # end_range is inclusive
+            self.pos += end+1
+            return b.content
+
+    def seek(self, offset, whence=0):
+        """Move to a new offset either relative or absolute. whence=0 is
+        absolute, whence=1 is relative, whence=2 is relative to the end.
+
+        Any relative or absolute seek operation which would result in a
+        negative position is undefined and that case can be ignored
+        in the implementation.
+
+        Any seek operation which moves the position after the stream
+        should succeed. tell() should report that position and read()
+        should return an empty bytes object."""
+        if whence == 0:
+            self.pos = offset
+        elif whence == 1:
+            self.pos += offset
+        elif whence == 2:
+            self.pos = self.size + offset

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -69,6 +69,19 @@ class BasicStore(object):
         assert long_value[3:5] == ok.read(2)
         assert long_value[5:8] == ok.read(3)
 
+    def test_open_seek_and_tell(self, store, key, long_value):
+        store.put(key, long_value)
+        ok = store.open(key)
+        ok.seek(10)
+        assert ok.tell() == 10
+        ok.seek(-6, 1)
+        assert ok.tell() == 4
+        with pytest.raises(IOError):
+            ok.seek(-6, 1)
+        assert ok.tell() == 4
+        assert long_value[4] == ok.read(1)
+        assert ok.tell() == 5
+
     def test_key_error_on_nonexistant_get(self, store, key):
         with pytest.raises(KeyError):
             store.get(key)

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -69,19 +69,6 @@ class BasicStore(object):
         assert long_value[3:5] == ok.read(2)
         assert long_value[5:8] == ok.read(3)
 
-    def test_open_seek_and_tell(self, store, key, long_value):
-        store.put(key, long_value)
-        ok = store.open(key)
-        ok.seek(10)
-        assert ok.tell() == 10
-        ok.seek(-6, 1)
-        assert ok.tell() == 4
-        with pytest.raises(IOError):
-            ok.seek(-6, 1)
-        assert ok.tell() == 4
-        assert long_value[4] == ok.read(1)
-        assert ok.tell() == 5
-
     def test_key_error_on_nonexistant_get(self, store, key):
         with pytest.raises(KeyError):
             store.get(key)

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -52,6 +52,7 @@ class TestAzureStorage(BasicStore):
     def test_open_seek_and_tell(self, store, key, long_value):
         store.put(key, long_value)
         ok = store.open(key)
+        assert ok.seekable()
         ok.seek(10)
         assert ok.tell() == 10
         ok.seek(-6, 1)
@@ -70,6 +71,9 @@ class TestAzureStorage(BasicStore):
         length_lv = len(long_value)
         assert long_value[length_lv - 1:length_lv] == ok.read(1)
         assert ok.tell() == length_lv
+        ok.seek(length_lv + 10, 0)
+        assert ok.tell() == length_lv + 10
+        assert len(ok.read()) == 0
 
 
 class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -59,7 +59,7 @@ class TestAzureStorage(BasicStore):
         with pytest.raises(IOError):
             ok.seek(-6, 1)
         assert ok.tell() == 4
-        assert long_value[4] == ok.read(1)
+        assert long_value[4:5] == ok.read(1)
         assert ok.tell() == 5
 
 

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -57,10 +57,19 @@ class TestAzureStorage(BasicStore):
         ok.seek(-6, 1)
         assert ok.tell() == 4
         with pytest.raises(IOError):
+            ok.seek(-1, 0)
+        with pytest.raises(IOError):
             ok.seek(-6, 1)
+        with pytest.raises(IOError):
+            ok.seek(-len(long_value) - 1, 2)
+
         assert ok.tell() == 4
         assert long_value[4:5] == ok.read(1)
         assert ok.tell() == 5
+        ok.seek(-1, 2)
+        length_lv = len(long_value)
+        assert long_value[length_lv - 1:length_lv] == ok.read(1)
+        assert ok.tell() == length_lv
 
 
 class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -49,13 +49,6 @@ class TestAzureStorage(BasicStore):
                                   public=False)
         s.delete_container(container)
 
-    def test_key_error_on_nonexistant_open_2(self, store, key, value):
-        store.put(key, value)
-        handle = store.open(key)
-        store.delete(key)
-        with pytest.raises(KeyError):
-            handle.read()
-
 
 class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
     @pytest.fixture

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -49,6 +49,13 @@ class TestAzureStorage(BasicStore):
                                   public=False)
         s.delete_container(container)
 
+    def test_key_error_on_nonexistant_open_2(self, store, key, value):
+        store.put(key, value)
+        handle = store.open(key)
+        store.delete(key)
+        with pytest.raises(KeyError):
+            handle.read()
+
 
 class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
     @pytest.fixture

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -49,6 +49,19 @@ class TestAzureStorage(BasicStore):
                                   public=False)
         s.delete_container(container)
 
+    def test_open_seek_and_tell(self, store, key, long_value):
+        store.put(key, long_value)
+        ok = store.open(key)
+        ok.seek(10)
+        assert ok.tell() == 10
+        ok.seek(-6, 1)
+        assert ok.tell() == 4
+        with pytest.raises(IOError):
+            ok.seek(-6, 1)
+        assert ok.tell() == 4
+        assert long_value[4] == ok.read(1)
+        assert ok.tell() == 5
+
 
 class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
     @pytest.fixture


### PR DESCRIPTION
Hi,
for reading partial data from (potentially big) blobs, it is great to have a real file-like open() interface, which does not buffer the whole file in the background.
This PR implements this for the azure backend.