### PR TITLE
Remove seek() for botostore and set seekable: False for it

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,5 +1,9 @@
 Changelog
 *********
+0.11.7
+======
+* removed seek() and tell() API for file handles opened in the botostore, due to it leaking HTTP connections to S3.
+
 0.11.6
 ======
 * Support seek() and tell() API for file handles opened in the botostore.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(name='simplekv',
-      version='0.11.6',
+      version='0.11.7',
       description=('A key-value storage for binary data, support many '
                    'backends.'),
       long_description=read('README.rst'),

--- a/simplekv/net/botostore.py
+++ b/simplekv/net/botostore.py
@@ -99,26 +99,10 @@ class BotoStore(KeyValueStore, UrlMixin, CopyMixin):
                 return KeyFile.read(self, size)
 
             def seekable(self):
-                return True
+                return False
 
             def readable(self):
                 return True
-
-            def seek(self, offset, whence=os.SEEK_SET):
-                if self.closed:
-                    raise ValueError("I/O operation on closed file")
-                if whence == os.SEEK_SET:
-                    if offset < 0:
-                        raise IOError('seek would move position outside the file')
-                    return KeyFile.seek(self, offset, whence)
-                elif whence == os.SEEK_CUR:
-                    if self.tell() + offset < 0:
-                        raise IOError('seek would move position outside the file')
-                    return KeyFile.seek(self, offset, whence)
-                elif whence == os.SEEK_END:
-                    if self.key.size + offset < 0:
-                        raise IOError('seek would move position outside the file')
-                    return KeyFile.seek(self, offset, whence)
 
         k = self.__new_key(key)
         with map_boto_exceptions(key=key):

--- a/tests/test_boto_store.py
+++ b/tests/test_boto_store.py
@@ -9,7 +9,7 @@ boto = pytest.importorskip('boto')
 from simplekv.net.botostore import BotoStore
 from simplekv._compat import BytesIO
 
-from basic_store import BasicStore, OpenSeekTellStore
+from basic_store import BasicStore
 from url_store import UrlStore
 from bucket_manager import boto_credentials, boto_bucket
 from conftest import ExtendedKeyspaceTests
@@ -28,7 +28,7 @@ def bucket(credentials):
         yield bucket
 
 
-class TestBotoStorage(BasicStore, UrlStore, OpenSeekTellStore):
+class TestBotoStorage(BasicStore, UrlStore):
     @pytest.fixture(params=[True, False])
     def reduced_redundancy(self, request):
         return request.param


### PR DESCRIPTION
Reason: The boto KeyFile implementation is buggy and leaks http connections.