### PR TITLE
Modernize requirements: move to azure-storage-blob

### DIFF
--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -3,9 +3,9 @@ Microsoft Azure Blob Storage
 
 Simplekv supports storing data in `Microsoft Azure Block Blob Storage <https://azure.microsoft.com/en-us/services/storage/blobs/>`_.
 
-The backend uses the `azure-storage <https://github.com/Azure/azure-storage-python>`_ python module to access the azure blob storage.
-Note that azure-storage is not a dependency for simplekv. You need to install it
-manually, otherwise you will see an :exc:`~exceptions.ImportError`.
+The backend uses the `azure-storage-blob <https://github.com/Azure/azure-storage-python/tree/master/azure-storage-blob>`_
+python distribution to access the azure blob storage. Note that `azure-storage-blob` is not
+a dependency for simplekv. You need to install it manually, otherwise you will see an :exc:`~exceptions.ImportError`.
 
 Here is a short example:
 

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -6,7 +6,7 @@ from basic_store import BasicStore, OpenSeekTellStore
 from conftest import ExtendedKeyspaceTests
 import pytest
 
-pytest.importorskip('azure.storage')
+pytest.importorskip('azure.storage.blob')
 
 
 def load_azure_credentials():
@@ -93,7 +93,7 @@ class TestAzureExceptionHandling(object):
         assert u"The specified container does not exist." in str(exc.value)
 
     def test_wrong_endpoint(self):
-        from azure.storage.retry import ExponentialRetry
+        from azure.storage.common.retry import ExponentialRetry
         container = uuid()
         conn_string = create_azure_conn_string(load_azure_credentials())
         conn_string += \
@@ -108,7 +108,7 @@ class TestAzureExceptionHandling(object):
         assert u"Failed to establish a new connection" in str(exc.value)
 
     def test_wrong_credentials(self):
-        from azure.storage.retry import ExponentialRetry
+        from azure.storage.common.retry import ExponentialRetry
         container = uuid()
         conn_string = \
             'DefaultEndpointsProtocol=https;AccountName={};AccountKey={}'.\

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
   pymongo
   dulwich
   boto
-  azure-storage
+  azure-storage-blob
   futures
 # ideally we would not need futures here but it doesn't work otherwise
 commands=py.test -n 4 --dist=loadfile --cov=simplekv -rs --pep8 --doctest-modules simplekv/idgen.py simplekv/fs.py tests


### PR DESCRIPTION
azure-storage was split up into several subpackages, e.g. 'azure-storage-blob'. This pull requests changes documentaiton and tests for this new situation (there were no actual library code changes necessary).