### PR TITLE
Add checksum feature for Azure blob storage.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Changelog
 *********
 
+0.11.9
+======
+* Add option to set the checksum for Azure blobs.
+
 0.11.8
 ======
 * Depend on azure-storage-blob, following the new naming scheme.

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -121,3 +121,47 @@ class TestAzureExceptionHandling(object):
         with pytest.raises(IOError) as exc:
             store.put(u"key", b"data")
         assert u"Incorrect padding" in str(exc.value)
+
+
+class TestChecksum(object):
+    CONTENT = b'\1\2\3\4'
+    EXPECTED_CHECKSUM = 'CNbAWiFRKnmh3+udKo8mLw=='
+    KEY = 'testkey'
+
+    @pytest.fixture
+    def store(self):
+        from azure.storage.blob import BlockBlobService
+
+        container = uuid()
+        conn_string = create_azure_conn_string(load_azure_credentials())
+        s = BlockBlobService(connection_string=conn_string)
+
+        yield AzureBlockBlobStore(
+            conn_string=conn_string,
+            container=container,
+            public=False,
+            checksum=True,
+        )
+        s.delete_container(container)
+
+    def _checksum(self, store):
+        return store.block_blob_service.get_blob_properties(
+            store.container,
+            self.KEY,
+        ).properties.content_settings.content_md5
+
+    def test_checksum_put(self, store):
+        store.put(self.KEY, self.CONTENT)
+        assert self._checksum(store) == self.EXPECTED_CHECKSUM
+
+    def test_checksum_put_file(self, store, tmpdir):
+        file_ = tmpdir.join('my_file')
+        file_.write(self.CONTENT)
+        store.put_file(self.KEY, file_.open())
+        assert self._checksum(store) == self.EXPECTED_CHECKSUM
+
+    def test_checksum_put_filename(self, store, tmpdir):
+        file_ = tmpdir.join('my_file')
+        file_.write(self.CONTENT)
+        store.put_file(self.KEY, str(file_))
+        assert self._checksum(store) == self.EXPECTED_CHECKSUM


### PR DESCRIPTION
Add the option of setting `content_md5` in the content settings of an Azure blob during upload. This is helpful for checking if two blobs are identical without having to download them.