### PR TITLE
azurestore: fix pickling support

### DIFF
--- a/simplekv/_compat.py
+++ b/simplekv/_compat.py
@@ -39,11 +39,9 @@ else:
 
 if not PY2:
     import pickle
-    import copyreg
 else:
     try:
         import cPickle as pickle
-        import copy_reg as copyreg
     except ImportError:
         import pickle
 

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -81,6 +81,25 @@ def test_azure_setgetstate():
     s.delete_container(container)
 
 
+def test_azure_store_attributes():
+    abbs = AzureBlockBlobStore('CONN_STR', 'CONTAINER',
+                               max_connections=42, checksum=True)
+    assert abbs.conn_string == 'CONN_STR'
+    assert abbs.container == 'CONTAINER'
+    assert abbs.public is False
+    assert abbs.create_if_missing is True
+    assert abbs.max_connections == 42
+    assert abbs.checksum is True
+
+    abbs2 = pickle.loads(pickle.dumps(abbs))
+    assert abbs2.conn_string == 'CONN_STR'
+    assert abbs2.container == 'CONTAINER'
+    assert abbs2.public is False
+    assert abbs2.create_if_missing is True
+    assert abbs2.max_connections == 42
+    assert abbs2.checksum is True
+
+
 class TestAzureExceptionHandling(object):
     def test_missing_container(self):
         container = uuid()


### PR DESCRIPTION
Pickling support for the azure store was broken, as not all of the attributes that are initialized in `__init__` were correctly pickled and unpickled during pickling. This now implements a slightly different method to support pickling which does not require to add each new instance attribute in two places.