### PR TITLE
azurestore: add socket_timeout parameter

### DIFF
--- a/simplekv/net/azurestore.py
+++ b/simplekv/net/azurestore.py
@@ -75,13 +75,15 @@ def map_azure_exceptions(key=None, exc_pass=()):
 
 class AzureBlockBlobStore(KeyValueStore):
     def __init__(self, conn_string=None, container=None, public=False,
-                 create_if_missing=True, max_connections=2, checksum=False):
+                 create_if_missing=True, max_connections=2, checksum=False,
+                 socket_timeout=None):
         self.conn_string = conn_string
         self.container = container
         self.public = public
         self.create_if_missing = create_if_missing
         self.max_connections = max_connections
         self.checksum = checksum
+        self.socket_timeout = socket_timeout
 
     # This allows recreating the block_blob_service instance when needed.
     # Together with the copyreg-registration at the bottom of this file,
@@ -90,7 +92,9 @@ class AzureBlockBlobStore(KeyValueStore):
     def block_blob_service(self):
         from azure.storage.blob import BlockBlobService, PublicAccess
         block_blob_service = BlockBlobService(
-            connection_string=self.conn_string)
+            connection_string=self.conn_string,
+            socket_timeout=self.socket_timeout,
+        )
         if self.create_if_missing:
             block_blob_service.create_container(
                 self.container,


### PR DESCRIPTION
The azure storage library configures default timeouts that are not suitable for all applications. In particular, it configures a timeout of 2000s which (together with the default re-try policy) can take several hours before an error is raised in case of connection issues.
This exposes the `socket_timeout` parameter of `BlockBlobService`, so applications can choose to override the default to a value that makes more sense in their context.