### PR TITLE
Workaround for missing has_key implementation

### DIFF
--- a/.travis/start_minio.sh
+++ b/.travis/start_minio.sh
@@ -10,5 +10,6 @@ export MINIO_ACCESS_KEY=minio
 export MINIO_SECRET_KEY=miniostorage
 
 mkdir -p ~/s3
-~/minio version
+
+~/minio --version
 ~/minio server ~/s3 &

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Changelog
 *********
 
+Next
+====
+
+* Fix an issue where `key in store` check for the new azure-storage-blob API did raise
+
 0.14.0
 ======
 

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -66,6 +66,11 @@ class TestAzureStorage(BasicStore, OpenSeekTellStore):
                                   public=False)
         _delete_container(conn_string, container)
 
+    def test_exists(self, store):
+        assert "key" not in store
+        store.put("key", b"value")
+        assert "key" in store
+
 
 class TestExtendedKeysAzureStorage(TestAzureStorage, ExtendedKeyspaceTests):
     @pytest.fixture


### PR DESCRIPTION
The new storage API apparently doesn't offer any exists implementation.

This is already reported on https://github.com/Azure/azure-sdk-for-python/issues/9507 and they suggest a rather crude workaround...