### PR TITLE
Fix and modernize build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,3 @@ ENV/
 
 # PyCharm
 .idea/
-
-azure_credentials.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
         - TOXENV=py36-old-azure-storage-blob
 
 services:
+- docker
 - redis-server
 - mongodb
 - postgresql
@@ -32,11 +33,11 @@ install: pip install tox coveralls
 
 before_script:
 - bash .travis/start_minio.sh
+- docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0 &
 - psql -c 'create database simplekv_test;' -U postgres
 - psql -c 'ALTER ROLE travis CONNECTION LIMIT -1;' -U postgres
 - mysql -e 'create database simplekv_test;'
 - mysql -e 'set global max_connections = 200;'
-- '[ -z "$encrypted_dea9dfb12f4a_key" ] || openssl aes-256-cbc -K $encrypted_dea9dfb12f4a_key -iv $encrypted_dea9dfb12f4a_iv -in azure_credentials.ini.enc -out azure_credentials.ini -d'
 
 script: tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,18 @@ matrix:
     - python: 2.7
       env:
         - TOXENV=py27
-    - python: 3.4
-      env:
-        - TOXENV=py34
     - python: 3.5
       env:
         - TOXENV=py35
     - python: 3.6
       env:
         - TOXENV=py36
+    - python: 3.7
+      env:
+        - TOXENV=py37
+    - python: 3.8
+      env:
+        - TOXENV=py38
     - python: 3.6
       env:
         - TOXENV=py36-old-azure-storage-blob

--- a/azure_credentials.ini
+++ b/azure_credentials.ini
@@ -1,0 +1,12 @@
+# Specify the azure account to use in the tests.
+# The default assumes you are running azurite (https://github.com/Azure/Azurite).
+# To skip the azure store tests, remove the ``account_name``.
+#
+# Note that only the first config section is parsed.
+
+[azure-tests]
+account_name=devstoreaccount1
+account_key=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+# these are not needed for a real azure blob store accounts; only set them for azurite:
+protocol=http
+endpoint=http://127.0.0.1:10000/devstoreaccount1

--- a/azure_credentials.ini.enc
+++ b/azure_credentials.ini.enc
@@ -1,1 +1,0 @@
-ÝÄŠr‹a°0l¢ø®§j1"Éá£5K<·¨±¸¢³1¢¼÷ÿ}5ìÞ"Š\¹Y“Wþ~gw?nÖM*Ñ7ÓÞÄô…El0—’YU‡¶Ë”SæŸ|–€%iŽë(û»Ï|_áÁéñŒ†ÔØåI<F}ó„x­sãžÛÃ<µ„;.!K‰žóÂ{lX~”‹L»v‹-Ž¶)>uØAâtg

--- a/docs/azure.rst
+++ b/docs/azure.rst
@@ -27,17 +27,26 @@ Here is a short example:
    print store.get(u'some-key')
 
 
-Unit testing
-============
+Testing
+=======
 
-The unit-tests for the azure backend are either run by travis on the main repo, or if you provide
-your own credentials via a `azure_credentials.ini`` file in the root folder of the project.
-An example looks like this:
+The tests for the azure backend either
 
-::
+ * use a real azure blob store account or
+ * use the `Azurite <https://github.com/Azure/Azurite>`_ blob storage emulator
 
-  [my-azure-test-account]
-  account_name=my_account_name
-  account_key=AZURE_TEST_KEY
+The travis tests use the second method.
+
+To test with a real blob store account, edit the file ``azure_credentials.ini``
+s.t. the first config section contains the actual account_name and account_key
+of your test account.
+
+To test against a locally running azurite instance make sure to start azurite::
+
+ docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0 &
+
+before running the tests.
+
+To skip the tests of the azure backend, comment out the ``account_name`` in the ``azure_credentials.ini`` file.
 
 .. autoclass:: simplekv.net.azurestore.AzureBlockBlobStore

--- a/simplekv/cache.py
+++ b/simplekv/cache.py
@@ -112,7 +112,7 @@ class CacheDecorator(StoreDecorator):
 
     def copy(self, source, dest):
         """Implementation of :meth:`~simplekv.CopyMixin.copy`.
-        
+
         Copies the data in the backing store and removes the destination key from the cache,
          in case it was already populated.
          Does not work when the backing store does not implement copy.

--- a/simplekv/contrib/__init__.py
+++ b/simplekv/contrib/__init__.py
@@ -7,8 +7,8 @@ from simplekv._compat import key_type
 
 VALID_NON_NUM_EXTENDED = VALID_NON_NUM + r"/ "
 VALID_KEY_REGEXP_EXTENDED = "^[%s0-9a-zA-Z]+$" % re.escape(VALID_NON_NUM_EXTENDED)
-"""This regular expression tests if a key is valid when the extended keyspace mixin is used. Allowed are all
-alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~/``. and spaces"""
+"""This regular expression tests if a key is valid when the extended keyspace mixin is used.
+Allowed are all alphanumeric characters, as well as ``!"`#$%&'()+,-.<=>?@[]^_{}~/``. and spaces"""
 VALID_KEY_RE_EXTENDED = re.compile(VALID_KEY_REGEXP_EXTENDED)
 """A compiled version of :data:`~simplekv.VALID_KEY_REGEXP_EXTENDED`."""
 

--- a/simplekv/crypt.py
+++ b/simplekv/crypt.py
@@ -24,11 +24,11 @@ class _HMACFileReader(object):
         if '' == self.buffer or 0 == n:
             return ''
 
-        new_read = self.source.read(n) if None != n else self.source.read()
-        finished = (None == n or len(new_read) != n)
+        new_read = self.source.read(n) if n is not None else self.source.read()
+        finished = (n is None or len(new_read) != n)
         self.buffer += new_read
 
-        if None != n:
+        if n is not None:
             offset = min(n, len(self.buffer) - self.hm.digest_size)
         else:
             offset = len(self.buffer) - self.hm.digest_size

--- a/simplekv/db/sql.py
+++ b/simplekv/db/sql.py
@@ -13,7 +13,8 @@ class SQLAlchemyStore(KeyValueStore, CopyMixin):
     def __init__(self, bind, metadata, tablename):
         self.bind = bind
 
-        self.table = Table(tablename, metadata,
+        self.table = Table(
+            tablename, metadata,
             # 250 characters is the maximum key length that we guarantee can be
             # handled by any kind of backend
             Column('key', String(250), primary_key=True),
@@ -32,8 +33,8 @@ class SQLAlchemyStore(KeyValueStore, CopyMixin):
 
     def _get(self, key):
         rv = self.bind.execute(
-                select([self.table.c.value], self.table.c.key == key).limit(1)
-             ).scalar()
+            select([self.table.c.value], self.table.c.key == key).limit(1)
+        ).scalar()
 
         if not rv:
             raise KeyError(key)

--- a/simplekv/gae.py
+++ b/simplekv/gae.py
@@ -25,11 +25,13 @@ class NdbStore(KeyValueStore):
         return obj.v
 
     def _has_key(self, key):
-        return None != self.obj_class.get_by_id(id=key)
+        return self.obj_class.get_by_id(id=key) is not None
 
     def iter_keys(self, prefix=u""):
         qry_iter = self.obj_class.query().iter(keys_only=True)
-        return filter(lambda k: k.string_id().startswith(prefix), (k.string_id() for k in qry_iter))
+        return filter(lambda k: k.string_id().startswith(prefix),
+                      (k.string_id() for k in qry_iter)
+                      )
 
     def _open(self, key):
         return StringIO(self._get(key))

--- a/simplekv/git.py
+++ b/simplekv/git.py
@@ -81,7 +81,6 @@ class GitCommitStore(KeyValueStore):
     def _key_components(self, key):
         return [c.encode('ascii') for c in key.split('/')]
 
-
     @property
     def _refname(self):
         return b'refs/heads/' + self.branch

--- a/simplekv/memory/redisstore.py
+++ b/simplekv/memory/redisstore.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from .. import KeyValueStore, TimeToLiveMixin, NOT_SET, FOREVER
 import re
 
+
 class RedisStore(TimeToLiveMixin, KeyValueStore):
     """Uses a redis-database as the backend.
 

--- a/simplekv/net/_azurestore_new.py
+++ b/simplekv/net/_azurestore_new.py
@@ -140,7 +140,9 @@ class AzureBlockBlobStore(KeyValueStore):
         from azure.storage.blob import ContentSettings
 
         if self.checksum:
-            content_settings = ContentSettings(content_md5=_byte_buffer_md5(data, b64encode=False))
+            content_settings = ContentSettings(
+                content_md5=_byte_buffer_md5(data, b64encode=False)
+            )
         else:
             content_settings = ContentSettings()
 

--- a/simplekv/net/_azurestore_old.py
+++ b/simplekv/net/_azurestore_old.py
@@ -4,7 +4,8 @@ This implements the AzureBlockBlobStore for `azure-storage-blob<12`
 import io
 from contextlib import contextmanager
 
-from ._azurestore_common import _byte_buffer_md5, _file_md5, _filename_md5, lazy_property, LAZY_PROPERTY_ATTR_PREFIX
+from ._azurestore_common import _byte_buffer_md5, _file_md5, _filename_md5,\
+    lazy_property, LAZY_PROPERTY_ATTR_PREFIX
 
 from .._compat import binary_type
 from .. import KeyValueStore
@@ -33,7 +34,8 @@ def map_azure_exceptions(key=None, exc_pass=()):
 
 class AzureBlockBlobStore(KeyValueStore):
     def __init__(self, conn_string=None, container=None, public=False,
-                 create_if_missing=True, max_connections=2, max_block_size=None, max_single_put_size=None,
+                 create_if_missing=True, max_connections=2,
+                 max_block_size=None, max_single_put_size=None,
                  checksum=False,
                  socket_timeout=None):
         self.conn_string = conn_string
@@ -98,7 +100,9 @@ class AzureBlockBlobStore(KeyValueStore):
         if prefix == "":
             prefix = None
         with map_azure_exceptions():
-            blobs = self.block_blob_service.list_blob_names(self.container, prefix=prefix, delimiter=delimiter)
+            blobs = self.block_blob_service.list_blob_names(
+                self.container, prefix=prefix, delimiter=delimiter
+            )
             return (blob.decode('utf-8') if isinstance(blob, binary_type)
                     else blob for blob in blobs)
 

--- a/simplekv/net/botostore.py
+++ b/simplekv/net/botostore.py
@@ -112,7 +112,7 @@ class BotoStore(KeyValueStore, UrlMixin, CopyMixin):
         if not self._has_key(source):
             raise KeyError(source)
         with map_boto_exceptions(key=source):
-                self.bucket.copy_key(self.prefix + dest, self.bucket.name, self.prefix + source)
+            self.bucket.copy_key(self.prefix + dest, self.bucket.name, self.prefix + source)
 
     def _put(self, key, data):
         k = self.__new_key(key)

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -48,9 +48,9 @@ def load_boto_credentials():
     cfg_fn = 'boto_credentials.ini'
 
     parser = ConfigParser({'host': 's3.amazonaws.com',
-                           'is_secure': True,
-                           'ordinary_calling_format': False,
-                           'port': None})
+                           'is_secure': 'true',
+                           'ordinary_calling_format': 'false',
+                           })
     if not parser.read(cfg_fn):
         pytest.skip('file {} not found'.format(cfg_fn))
 

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -12,23 +12,27 @@ asb = pytest.importorskip('azure.storage.blob')
 
 def get_azure_conn_string():
     cfg_fn = 'azure_credentials.ini'
-    parser = ConfigParser()
+    parser = ConfigParser({
+        'protocol': 'https',
+        'endpoint': '',
+        'account_name': '',
+    })
     result = parser.read(cfg_fn)
     if not result:
         pytest.skip('file {} not found'.format(cfg_fn))
 
     for section in parser.sections():
-        account_name = parser.get(section, 'account_name', fallback=None)
-        if account_name is None:
+        account_name = parser.get(section, 'account_name')
+        if not account_name:
             pytest.skip("no 'account_name' found in file {}".format(cfg_fn))
 
         account_key = parser.get(section, 'account_key')
-        protocol = parser.get(section, 'protocol', fallback='https')
-        endpoint = parser.get(section, 'endpoint', fallback=None)
+        protocol = parser.get(section, 'protocol')
+        endpoint = parser.get(section, 'endpoint')
         conn_string = 'DefaultEndpointsProtocol={};AccountName={};AccountKey={}'.format(
             protocol, account_name, account_key
         )
-        if endpoint is not None:
+        if endpoint:
             conn_string += ';BlobEndpoint={}'.format(endpoint)
         return conn_string
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
-envlist = py{27,34,35,36},py36-old-azure-storage-blob
-
-[pytest]
-pep8ignore = test_* E402
+envlist = py{27,35,36,37,38},py36-old-azure-storage-blob
 
 [testenv]
 # See https://github.com/boto/boto/issues/3717
@@ -11,7 +8,7 @@ setenv=
   BOTO_PATH=/dev/null
 deps=
   pytest
-  pytest-pep8
+  pycodestyle
   pytest-cov
   pytest-mock
   pytest-xdist
@@ -26,7 +23,9 @@ deps=
   azure-storage-blob
   futures
 # ideally we would not need futures here but it doesn't work otherwise
-commands=pytest -n 4 --dist=loadfile --cov=simplekv -rs --pep8 --doctest-modules simplekv/idgen.py simplekv/fs.py tests
+commands=
+  pycodestyle --ignore=E402,E741 --max-line-length 98 simplekv tests
+  pytest -n 4 --dist=loadfile --cov=simplekv -rs --doctest-modules simplekv/idgen.py simplekv/fs.py tests
 
 [testenv:py36-old-azure-storage-blob]
 # Test on one python version with the "old" code for azure-storage-blob<12

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@ setenv=
   BOTO_CONFIG=/dev/null
   BOTO_PATH=/dev/null
 deps=
-  pytest
+  # as workaround for https://github.com/pytest-dev/pytest/issues/6925
+  # use a somewhat older version of pytest:
+  pytest <= 5.3.5
   pycodestyle
   pytest-cov
   pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,6 @@ deps=
   pytest-mock
   mock
   azure-storage-blob<12
-commands=pytest tests/test_azure_store.py
+# For some reason, switching on usedevelop makes collecting coverage data much more reliable
+usedevelop=True
+commands=pytest --cov=simplekv tests/test_azure_store.py


### PR DESCRIPTION
 * fix an issue with azure-storage-blob 12 and python 2: the returned blob names are now of type `unicode`
 * use `pycodestyle` instead of the deprecated `pep8`
 * apply `pycodestyle` not only to the code in `tests/`, but to the actual library code. Note that some fixes were necessary to make it pass, I kept them in a separate commit for easier review
 * removed tests for python 3.4, added python 3.7 and python 3.8
 * run the azure tests in travis using azurite. This way, we don't need credentials for a real azure blob store account for the tests, which gives much better (earlier) test feedback that was missing earlier.