### PR TITLE
Add a Boto3Store class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ celerybeat-schedule
 venv/
 ENV/
 
+# Pipenv
+Pipfile
+Pipfile.lock
+
 # Spyder project settings
 .spyderproject
 

--- a/simplekv/net/boto3store.py
+++ b/simplekv/net/boto3store.py
@@ -80,6 +80,12 @@ class Boto3SimpleKeyFile(io.RawIOBase):
 
 class Boto3Store(KeyValueStore, CopyMixin):
     def __init__(self, bucket, prefix=''):
+        if isinstance(bucket, str):
+            import boto3
+            s3_resource = boto3.resource('s3')
+            bucket = s3_resource.Bucket(bucket)
+            if bucket not in s3_resource.buckets.all():
+                raise ValueError('invalid s3 bucket name')
         self.bucket = bucket
         self.prefix = prefix.strip().lstrip('/')
 
@@ -123,7 +129,7 @@ class Boto3Store(KeyValueStore, CopyMixin):
     def _copy(self, source, dest):
         obj = self.__new_object(dest)
         with map_boto3_exceptions(key=source):
-            obj.load()
+            self.__new_object(source).load()
             obj.copy_from(CopySource=self.bucket.name + '/' + self.prefix + source)
 
     def _put(self, key, data):

--- a/simplekv/net/boto3store.py
+++ b/simplekv/net/boto3store.py
@@ -21,7 +21,6 @@ def map_boto3_exceptions(key=None, exc_pass=()):
         raise IOError(str(ex))
 
 
-# todo: test this more thoroughly
 class Boto3SimpleKeyFile(io.RawIOBase):
     # see: https://alexwlchan.net/2019/02/working-with-large-s3-objects/
     # author: Alex Chan, license: MIT
@@ -30,7 +29,7 @@ class Boto3SimpleKeyFile(io.RawIOBase):
         self.position = 0
 
     def __repr__(self):
-        return "<%s s3_object=%r>" % (type(self).__name__, self.s3_object)
+        return "<%s s3_object=%r >" % (type(self).__name__, self.s3_object)
 
     @property
     def size(self):

--- a/simplekv/net/boto3store.py
+++ b/simplekv/net/boto3store.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# coding=utf8
+
+from .._compat import imap
+from .. import KeyValueStore, UrlMixin, CopyMixin
+from contextlib import contextmanager
+from shutil import copyfileobj
+import io
+
+
+@contextmanager
+def map_boto3_exceptions(key=None, exc_pass=()):
+    """Map boto-specific exceptions to the simplekv-API."""
+    from botocore.exceptions import ClientError
+
+    #try:
+    #    yield
+    #except StorageResponseError as e:
+    #    if e.code == 'NoSuchKey':
+    #        raise KeyError(key)
+    #    raise IOError(str(e))
+    except (ClientError,) as e:
+        if e.__class__.__name__ not in exc_pass:
+            raise IOError(str(e))
+
+
+# todo: test this more thoroughly
+class Boto3SimpleKeyFile(io.RawIOBase):
+    # see: https://alexwlchan.net/2019/02/working-with-large-s3-objects/
+    # author: Alex Chan, license: MIT
+    def __init__(self, s3_object):
+        self.s3_object = s3_object
+        self.position = 0
+
+    def __repr__(self):
+        return "<%s s3_object=%r>" % (type(self).__name__, self.s3_object)
+
+    @property
+    def size(self):
+        return self.s3_object.content_length
+
+    def tell(self):
+        return self.position
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if whence == io.SEEK_SET:
+            self.position = offset
+        elif whence == io.SEEK_CUR:
+            self.position += offset
+        elif whence == io.SEEK_END:
+            self.position = self.size + offset
+        else:
+            raise ValueError("invalid whence (%r, should be %d, %d, %d)" % (
+                whence, io.SEEK_SET, io.SEEK_CUR, io.SEEK_END
+            ))
+
+        return self.position
+
+    def seekable(self):
+        return True
+
+    def read(self, size=-1):
+        if size == -1:
+            # Read to the end of the file
+            range_header = "bytes=%d-" % self.position
+            self.seek(offset=0, whence=io.SEEK_END)
+        else:
+            new_position = self.position + size
+
+            # If we're going to read beyond the end of the object, return
+            # the entire object.
+            if new_position >= self.size:
+                return self.read()
+
+            range_header = "bytes=%d-%d" % (self.position, new_position - 1)
+            self.seek(offset=size, whence=io.SEEK_CUR)
+
+        return self.s3_object.get(Range=range_header)["Body"].read()
+
+    def readable(self):
+        return True
+
+
+class Boto3Store(KeyValueStore, UrlMixin, CopyMixin):
+    def __init__(self, bucket, prefix='', url_valid_time=0,
+                 reduced_redundancy=False, public=False, metadata=None):
+        self.prefix = prefix.strip().lstrip('/')
+        self.bucket = bucket
+        self.reduced_redundancy = reduced_redundancy
+        self.public = public
+        self.url_valid_time = url_valid_time
+        self.metadata = metadata or {}
+
+    def __new_key(self, name):
+        # todo: test that this works if the object hasn't been created yet
+        key = self.bucket.Object(self.prefix + name)
+        key.put(Metadata=self.metadata)
+        return key
+
+    def iter_keys(self, prefix=u""):
+        with map_boto3_exceptions():
+            prefix_len = len(self.prefix)
+            return imap(lambda k: k.key[prefix_len:],
+                        self.bucket.objects.filter(self.prefix + prefix))
+
+    def _has_key(self, key):
+        from botocore.exceptions import ClientError
+        with map_boto3_exceptions(key=key):
+            try:
+                self.bucket.Object(self.prefix + key).load()
+            except ClientError as error:
+                if error.response['Error']['Code'] == '404':
+                    return False
+                raise error
+            return True
+
+    def _delete(self, key):
+        # todo: handle the exception of the key does not exist
+        self.bucket.Object(self.prefix + key).delete()
+
+    def _get(self, key):
+        k = self.__new_key(key)
+        with map_boto3_exceptions(key=key):
+            obj = k.get()
+            return obj.get()['Body'].read()
+
+    def _get_file(self, key, file):
+        k = self.__new_key(key)
+        with map_boto3_exceptions(key=key):
+            obj = k.get()
+            return copyfileobj(obj['Body'], file)
+
+    def _get_filename(self, key, filename):
+        k = self.__new_key(key)
+        with map_boto3_exceptions(key=key):
+            obj = k.get()
+            with open(filename, 'wb') as file:
+                return copyfileobj(obj['Body'], file)
+
+    def _open(self, key):
+        k = self.__new_key(key)
+        with map_boto3_exceptions(key=key):
+            return Boto3SimpleKeyFile(k)
+
+    def _copy(self, source, dest):
+        if not self._has_key(source):
+            raise KeyError(source)
+        with map_boto3_exceptions(key=source):
+            # todo: test that this works as written being relative from self.bucket instead
+            # of being hard-coded like https://stackoverflow.com/a/32504096/2722961
+            self.bucket.Object(self.prefix + dest).copy_from(CopySource=self.prefix + source)
+
+    def _put(self, key, data):
+        k = self.__new_key(key)
+        with map_boto3_exceptions(key=key):
+            k.put(Body=data)
+            return key
+
+    def _put_file(self, key, file):
+        k = self.__new_key(key)
+        with map_boto3_exceptions(key=key):
+            k.put(Body=file)
+            return key
+
+    def _put_filename(self, key, filename):
+        with open(filename, 'rb') as file:
+            return self._put(key, file)
+
+    def _url_for(self, key):
+        k = self.__new_key(key)
+        params = {
+            'Bucket' self.bucket.name,
+            'Key': k.key
+        }
+        # todo: finish this, see: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html
+        with map_boto3_exceptions(key=key):
+            return s3_client.generate_presigned_url('get_object',
+                                             Params=params,
+                                             ExpiresIn=self.url_valid_time)

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -32,6 +32,22 @@ def boto_bucket(access_key, secret_key, host,
         key.delete()
     bucket.delete()
 
+@contextmanager
+def boto3_bucket(access_key, secret_key, host,
+                 bucket_name=None, **kwargs):
+    import boto3
+    name = bucket_name or 'testrun-bucket-{}'.format(uuid())
+    s3_client = boto3.client('s3')
+    s3_client.create_bucket(Bucket=name)
+    s3_resource = boto3.resource('s3')
+    bucket = s3_resource.Bucket(name)
+
+    yield bucket
+
+    for key in bucket.objects.all():
+        key.delete()
+    bucket.delete()
+
 
 def load_boto_credentials():
     # loaded from the same place tox.ini. here's a sample

--- a/tests/test_boto3_store.py
+++ b/tests/test_boto3_store.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+import os
+
+import pytest
+
+boto3 = pytest.importorskip('boto3')
+from simplekv.net.botostore import BotoStore
+from simplekv._compat import BytesIO
+
+from basic_store import BasicStore
+from url_store import UrlStore
+from bucket_manager import boto_credentials, boto3_bucket
+from conftest import ExtendedKeyspaceTests
+from simplekv.contrib import ExtendedKeyspaceMixin
+
+
+@pytest.fixture(params=boto_credentials,
+                ids=[c['access_key'] for c in boto_credentials])
+def credentials(request):
+    return request.param
+
+
+@pytest.yield_fixture()
+def bucket(credentials):
+    with boto3_bucket(**credentials) as bucket:
+        yield bucket
+
+
+class TestBotoStorage(BasicStore, UrlStore):
+    @pytest.fixture(params=[True, False])
+    def reduced_redundancy(self, request):
+        return request.param
+
+    @pytest.fixture
+    def storage_class(self, reduced_redundancy):
+        return 'REDUCED_REDUNDANCY' if reduced_redundancy else 'STANDARD'
+
+    @pytest.fixture(params=['', '/test-prefix'])
+    def prefix(self, request):
+        return request.param
+
+    @pytest.fixture
+    def store(self, bucket, prefix, reduced_redundancy):
+        return BotoStore(bucket, prefix, reduced_redundancy=reduced_redundancy)
+
+    # Disable max key length test as it leads to problems with minio
+    test_max_key_length = None
+
+    def test_get_filename_nonexistant(self, store, key, tmp_path):
+        with pytest.raises(KeyError):
+            store.get_file(key, os.path.join(str(tmp_path), 'a'))
+
+    def test_key_error_on_nonexistant_get_filename(self, store, key, tmp_path):
+        with pytest.raises(KeyError):
+            store.get_file(key, os.path.join(str(tmp_path), 'a'))
+
+    def test_storage_class_put(
+        self, store, prefix, key, value, storage_class, bucket
+    ):
+        store.put(key, value)
+
+        keyname = prefix + key
+
+        if storage_class != 'STANDARD':
+            pytest.xfail('boto does not support checking the storage class?')
+
+        assert bucket.Object(keyname).storage_class == storage_class
+
+    def test_storage_class_putfile(
+        self, store, prefix, key, value, storage_class, bucket
+    ):
+        store.put_file(key, BytesIO(value))
+
+        keyname = prefix + key
+
+        if storage_class != 'STANDARD':
+            pytest.xfail('boto does not support checking the storage class?')
+        assert bucket.Object(keyname).storage_class == storage_class
+
+
+class TestExtendedKeyspaceBotoStore(TestBotoStorage, ExtendedKeyspaceTests):
+    @pytest.fixture
+    def store(self, bucket, prefix, reduced_redundancy):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, BotoStore):
+            pass
+        return ExtendedKeyspaceStore(bucket, prefix,
+                                     reduced_redundancy=reduced_redundancy)

--- a/tests/test_boto3_store.py
+++ b/tests/test_boto3_store.py
@@ -6,6 +6,7 @@ import pytest
 
 boto3 = pytest.importorskip('boto3')
 from simplekv.net.boto3store import Boto3Store
+from simplekv._compat import BytesIO
 
 from basic_store import BasicStore
 from url_store import UrlStore
@@ -27,13 +28,21 @@ def bucket(credentials):
 
 
 class TestBoto3Storage(BasicStore, UrlStore):
+    @pytest.fixture(params=[True, False])
+    def reduced_redundancy(self, request):
+        return request.param
+
+    @pytest.fixture
+    def storage_class(self, reduced_redundancy):
+        return 'REDUCED_REDUNDANCY' if reduced_redundancy else None
+
     @pytest.fixture(params=['', '/test-prefix'])
     def prefix(self, request):
         return request.param
 
     @pytest.fixture
-    def store(self, bucket, prefix):
-        return Boto3Store(bucket, prefix)
+    def store(self, bucket, prefix, reduced_redundancy):
+        return Boto3Store(bucket, prefix, reduced_redundancy=reduced_redundancy)
 
     # Disable max key length test as it leads to problems with minio
     test_max_key_length = None
@@ -46,10 +55,25 @@ class TestBoto3Storage(BasicStore, UrlStore):
         with pytest.raises(KeyError):
             store.get_file(key, os.path.join(str(tmp_path), 'a'))
 
+    def test_storage_class_put(
+        self, store, prefix, key, value, storage_class, bucket
+    ):
+        store.put(key, value)
+        obj = bucket.Object(prefix.lstrip('/') + key)
+        assert obj.storage_class == storage_class
+
+    def test_storage_class_putfile(
+        self, store, prefix, key, value, storage_class, bucket
+    ):
+        store.put_file(key, BytesIO(value))
+        obj = bucket.Object(prefix.lstrip('/') + key)
+        assert obj.storage_class == storage_class
+
 
 class TestExtendedKeyspaceBoto3Store(TestBoto3Storage, ExtendedKeyspaceTests):
     @pytest.fixture
-    def store(self, bucket, prefix):
+    def store(self, bucket, prefix, reduced_redundancy):
         class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, Boto3Store):
             pass
-        return ExtendedKeyspaceStore(bucket, prefix)
+        return ExtendedKeyspaceStore(bucket, prefix,
+                                     reduced_redundancy=reduced_redundancy)

--- a/tests/test_boto3_store.py
+++ b/tests/test_boto3_store.py
@@ -8,6 +8,7 @@ boto3 = pytest.importorskip('boto3')
 from simplekv.net.boto3store import Boto3Store
 
 from basic_store import BasicStore
+from url_store import UrlStore
 from bucket_manager import boto_credentials, boto3_bucket
 from conftest import ExtendedKeyspaceTests
 from simplekv.contrib import ExtendedKeyspaceMixin
@@ -25,7 +26,7 @@ def bucket(credentials):
         yield bucket
 
 
-class TestBoto3Storage(BasicStore):
+class TestBoto3Storage(BasicStore, UrlStore):
     @pytest.fixture(params=['', '/test-prefix'])
     def prefix(self, request):
         return request.param

--- a/tests/test_boto3_store.py
+++ b/tests/test_boto3_store.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 boto3 = pytest.importorskip('boto3')
-from simplekv.net.botostore import BotoStore
+from simplekv.net.boto3store import Boto3Store
 from simplekv._compat import BytesIO
 
 from basic_store import BasicStore
@@ -27,7 +27,7 @@ def bucket(credentials):
         yield bucket
 
 
-class TestBotoStorage(BasicStore, UrlStore):
+class TestBoto3Storage(BasicStore, UrlStore):
     @pytest.fixture(params=[True, False])
     def reduced_redundancy(self, request):
         return request.param
@@ -41,8 +41,8 @@ class TestBotoStorage(BasicStore, UrlStore):
         return request.param
 
     @pytest.fixture
-    def store(self, bucket, prefix, reduced_redundancy):
-        return BotoStore(bucket, prefix, reduced_redundancy=reduced_redundancy)
+    def store(self, bucket, prefix):
+        return Boto3Store(bucket, prefix)
 
     # Disable max key length test as it leads to problems with minio
     test_max_key_length = None
@@ -79,10 +79,9 @@ class TestBotoStorage(BasicStore, UrlStore):
         assert bucket.Object(keyname).storage_class == storage_class
 
 
-class TestExtendedKeyspaceBotoStore(TestBotoStorage, ExtendedKeyspaceTests):
+class TestExtendedKeyspaceBoto3Store(TestBoto3Storage, ExtendedKeyspaceTests):
     @pytest.fixture
-    def store(self, bucket, prefix, reduced_redundancy):
-        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, BotoStore):
+    def store(self, bucket, prefix):
+        class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, Boto3Store):
             pass
-        return ExtendedKeyspaceStore(bucket, prefix,
-                                     reduced_redundancy=reduced_redundancy)
+        return ExtendedKeyspaceStore(bucket, prefix)

--- a/tests/test_boto3_store.py
+++ b/tests/test_boto3_store.py
@@ -6,10 +6,8 @@ import pytest
 
 boto3 = pytest.importorskip('boto3')
 from simplekv.net.boto3store import Boto3Store
-from simplekv._compat import BytesIO
 
 from basic_store import BasicStore
-from url_store import UrlStore
 from bucket_manager import boto_credentials, boto3_bucket
 from conftest import ExtendedKeyspaceTests
 from simplekv.contrib import ExtendedKeyspaceMixin
@@ -27,15 +25,7 @@ def bucket(credentials):
         yield bucket
 
 
-class TestBoto3Storage(BasicStore, UrlStore):
-    @pytest.fixture(params=[True, False])
-    def reduced_redundancy(self, request):
-        return request.param
-
-    @pytest.fixture
-    def storage_class(self, reduced_redundancy):
-        return 'REDUCED_REDUNDANCY' if reduced_redundancy else 'STANDARD'
-
+class TestBoto3Storage(BasicStore):
     @pytest.fixture(params=['', '/test-prefix'])
     def prefix(self, request):
         return request.param
@@ -54,29 +44,6 @@ class TestBoto3Storage(BasicStore, UrlStore):
     def test_key_error_on_nonexistant_get_filename(self, store, key, tmp_path):
         with pytest.raises(KeyError):
             store.get_file(key, os.path.join(str(tmp_path), 'a'))
-
-    def test_storage_class_put(
-        self, store, prefix, key, value, storage_class, bucket
-    ):
-        store.put(key, value)
-
-        keyname = prefix + key
-
-        if storage_class != 'STANDARD':
-            pytest.xfail('boto does not support checking the storage class?')
-
-        assert bucket.Object(keyname).storage_class == storage_class
-
-    def test_storage_class_putfile(
-        self, store, prefix, key, value, storage_class, bucket
-    ):
-        store.put_file(key, BytesIO(value))
-
-        keyname = prefix + key
-
-        if storage_class != 'STANDARD':
-            pytest.xfail('boto does not support checking the storage class?')
-        assert bucket.Object(keyname).storage_class == storage_class
 
 
 class TestExtendedKeyspaceBoto3Store(TestBoto3Storage, ExtendedKeyspaceTests):


### PR DESCRIPTION
This implements #84 and adds a `Boto3Store` class using the `boto3` library to use S3 as a storage backend.

The code and tests were largely based on the existing `BotoStore` backend. ~~I'm hoping these tests pass, but I'm getting some errors running them on my system and I can't quite tell if that's expected or not due to the authentication. If the tests need to be updated just let me know and I'd be happy to take care of that.~~

~~I left the `UrlMixin` out because in addition to a bucket, you'd need a `boto3.client` instance configured for S3. I couldn't find an obvious way to create this from the bucket instance, so the user would need to initialize that every time, or we could initialize it for them but that starts to make assumptions about how they handle authentication. As a third option we could raise `RuntimeError` if `url_for` is called and an client wasn't passed to `__init__`. I opted to leave it out entirely but if you like one of those options more, just let me know.~~

**Update:** The `UrlMixin` support is all set and all of the unit tests should be passing. One thing I wanted to note regarding the URL support is that the `url_valid_time` parameter is only used if it's set and the object is not an existing object that is publicly accessible. This allows the user to set `public=True` and then obtain URLs that will be valid indefinitely as opposed to constrained by the 1 week limit that S3 imposes.

Like the original `BotoStore` class, the `bucket` argument is expected to be a `boto3` Bucket instance. However, if it's a string it will be used as the bucket name and a new Bucket instance will be created as long as it already exists.

Thanks!