### PR TITLE
Add move support to the CopyMixin

### DIFF
--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -466,7 +466,7 @@ class CopyMixin(object):
     """Exposes a copy operation, if the backend supports it."""
 
     def copy(self, source, dest):
-        """Copies a key. The destination is overwritten if does exist.
+        """Copies a key. The destination is overwritten if it does exist.
 
         :param source: The source key to copy
         :param dest: The destination for the copy
@@ -478,3 +478,25 @@ class CopyMixin(object):
         self._check_valid_key(source)
         self._check_valid_key(dest)
         return self._copy(source, dest)
+
+    def _copy(self, source, dest):
+        raise NotImplementedError
+
+    def move(self, source, dest):
+        """Moves a key. The destination is overwritten if it does exist.
+
+        :param source: The source key to move
+        :param dest: The destination for the move
+
+        :returns: The destination key
+
+        :raises: exceptions.ValueError: If the source or target key are not valid
+        :raises: exceptions.KeyError: If the source key was not found"""
+        self._check_valid_key(source)
+        self._check_valid_key(dest)
+        return self._move(source, dest)
+
+    def _move(self, source, dest):
+        self._copy(source, dest)
+        self._delete(source)
+        return dest


### PR DESCRIPTION
This adds the ability to move / rename a key to the CopyMixin. Under the hood, the default implementation performs a copy operation followed by a delete operation to remove the original key. If the backend directly support a move operation, then it can be implemented in the standard way by overriding the `_move` method to use what is presumably the more efficient method.

## Example Usage
Shows `key1` being copied to `key2` and then that the data is accessible as `key2` while `key1` is then invalid.

```
In [4]: from simplekv.fs import FilesystemStore 
   ...:  
   ...: store = FilesystemStore('./data') 
   ...:  
   ...: store.put(u'key1', b'hello')                                                                                                                                                                               
Out[4]: 'key1'

In [5]: store.move(u'key1', u'key2')                                                                                                                                                                               
Out[5]: 'key2'

In [6]: store.get(u'key2')                                                                                                                                                                                         
Out[6]: b'hello'

In [7]: store.get(u'key1')                                                                                                                                                                                         
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
~/Repositories/simplekv/simplekv/fs.py in _open(self, key)
     77         try:
---> 78             f = open(self._build_filename(key), 'rb')
     79             return f

FileNotFoundError: [Errno 2] No such file or directory: '/home/steiner/Repositories/simplekv/data/key1'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
<ipython-input-7-5fee0dbea39d> in <module>
----> 1 store.get(u'key1')

~/Repositories/simplekv/simplekv/__init__.py in get(self, key)
     73         """
     74         self._check_valid_key(key)
---> 75         return self._get(key)
     76 
     77     def get_file(self, key, file):

~/Repositories/simplekv/simplekv/__init__.py in _get(self, key)
    235         buf = BytesIO()
    236 
--> 237         self._get_file(key, buf)
    238 
    239         return buf.getvalue()

~/Repositories/simplekv/simplekv/__init__.py in _get_file(self, key, file)
    254         # this allows us to support file-like objects without close as well,
    255         # such as BytesIO.
--> 256         source = self.open(key)
    257         try:
    258             while True:

~/Repositories/simplekv/simplekv/__init__.py in open(self, key)
    156         """
    157         self._check_valid_key(key)
--> 158         return self._open(key)
    159 
    160     def put(self, key, data):

~/Repositories/simplekv/simplekv/fs.py in _open(self, key)
     80         except IOError as e:
     81             if 2 == e.errno:
---> 82                 raise KeyError(key)
     83             else:
     84                 raise

KeyError: 'key1'

In [8]:                                                    
```