### PR TITLE
Allow decorators to be pickled

### DIFF
--- a/simplekv/decorator.py
+++ b/simplekv/decorator.py
@@ -16,7 +16,8 @@ class StoreDecorator(object):
         self._dstore = store
 
     def __getattr__(self, attr):
-        return getattr(self._dstore, attr)
+        store = object.__getattribute__(self, "_dstore")
+        return getattr(store, attr)
 
     def __contains__(self, *args, **kwargs):
         return self._dstore.__contains__(*args, **kwargs)

--- a/tests/test_prefix_decorator.py
+++ b/tests/test_prefix_decorator.py
@@ -76,3 +76,8 @@ class TestPrefixDecorator(BasicStore):
 
         assert store.get(key) == pv
         assert store2.get(key) == pv2
+
+    def test_pickle(self, store):
+        import pickle
+        rountrip = pickle.loads(pickle.dumps(store))
+        assert isinstance(rountrip, PrefixDecorator)


### PR DESCRIPTION
The `self._dstore` triggers an infinite recursion error when trying to pickle a decorated store. There are reasons why certain stores are not serializable but there is no reason why the decorator should be a problem