### PR TITLE
Proposal for closable stores

### DIFF
--- a/simplekv/__init__.py
+++ b/simplekv/__init__.py
@@ -335,6 +335,23 @@ class KeyValueStore(object):
         with open(filename, 'rb') as source:
             return self._put_file(key, source)
 
+    def close(self):
+        """Specific store implementations might require teardown methods.
+        (Dangling ports, unclosed files). This allows calling close also
+        for stores, which do not require this.
+        """
+        return
+
+    def __enter__(self):
+        """Support for with clause for automatic calling of close.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Support for with clause for automatic calling of close.
+        """
+        self.close()
+
 
 class UrlMixin(object):
     """Supports getting a download URL for keys."""

--- a/simplekv/decorator.py
+++ b/simplekv/decorator.py
@@ -25,6 +25,15 @@ class StoreDecorator(object):
     def __iter__(self, *args, **kwargs):
         return self._dstore.__iter__(*args, **kwargs)
 
+    def close(self):
+        self._dstore.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
 
 class KeyTransformingDecorator(StoreDecorator):
     # currently undocumented (== not advertised as a feature)

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -128,7 +128,8 @@ class BasicStore(object):
             tmp.write(value)
             tmp.flush()
 
-            store.put_file(key, open(tmp.name, 'rb'))
+            with open(tmp.name, 'rb') as infile:
+                store.put_file(key, infile)
 
             assert store.get(key) == value
 
@@ -137,8 +138,8 @@ class BasicStore(object):
         out_filename = os.path.join(str(tmp_path), 'output')
 
         store.get_file(key, out_filename)
-
-        assert open(out_filename, 'rb').read() == value
+        with open(out_filename, 'rb') as infile:
+            assert infile.read() == value
 
     def test_get_into_stream(self, store, key, value):
         store.put(key, value)

--- a/tests/test_keyvaluestore_base.py
+++ b/tests/test_keyvaluestore_base.py
@@ -1,0 +1,8 @@
+from unittest import mock
+from simplekv import KeyValueStore
+
+def test_keyvaluestore_enter_exit():
+    with mock.patch("simplekv.KeyValueStore.close") as closefunc:
+        with KeyValueStore() as kv:
+            pass
+        closefunc.assert_called_once()


### PR DESCRIPTION
### Motivation

simplekv does not have a possibility to **close** a store, if opening it requires opening e.g. file descriptors or ports. This can for example be observed in the Azure blobstore unit tests, when turning on ResourceWarnings, which generates 1253 warnings and  10000 lines noting that ports were not closed:

```
pytest -Wonce tests/test_azure_store.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/me/src/simplekv
collected 708 items

.../python3.10/site-packages/_pytest/runner.py:136: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 46992), raddr=('127.0.0.1', 10000)>
    item.funcargs = None  # type: ignore[attr-defined]

... 10000 lines omitted ...

=============================================================================== 572 passed, 136 skipped, 1253 warnings in 34.96s ================================================================================
```
When using simplekv in another project, it is currently impossible to close these stores manually and one will observe the same warnings. This gets even worse, if the store is wrapped behind multiple decorators so that one has no clue anymore, which type of store is actually instantiated

### Solution
In this PR we extend the **KeyValueStore** and **Decorator** baseclasses with closing support and implement the baseclass in the _azurestore_new store as an example. 

With the implementation we can do
```
with MyKeyValueStoreClass() as kv:
    kv.dothings()
```
and it will automatically close. Manual closing via kv.close() is also supported.

With this change (and actually closing the stores) the warning count of test_azure_store.py is now 0 again:
```
pytest -Wonce tests/test_azure_store.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/ctfy/src/simplekv
collected 711 items

tests/test_azure_store.py ................................................ssssssssssssssssssssssssssssssssssss......ssssss...............ssssssssssssssssss.............................................. [ 24%]
...................................................................................................................................................................................................ssssss [ 52%]
ssssssssssssssssssssssssssssssssssssssssss........ssssssss.................ssssssssssssssssssss.......................................................................................................... [ 81%]
......................................................................................................................................                                                                    [100%]

======================================================================================= 575 passed, 136 skipped in 35.08s =======================================================================================
```



