### PR TITLE
added support for sqlalchemy 2

### DIFF
--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -38,14 +38,14 @@ class TestSQLAlchemyStore(BasicStore):
             pytest.skip('could not connect to database {}'.format(dsn))
         return engine
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def store(self, engine):
-        metadata = MetaData(bind=engine)
+        metadata = MetaData()
         store = SQLAlchemyStore(engine, metadata, 'simplekv_test')
         # create table
-        store.table.create()
+        store.table.create(bind=engine)
         yield store
-        metadata.drop_all()
+        metadata.drop_all(bind=engine)
 
 
 class TestExtendedKeyspaceSQLAlchemyStore(TestSQLAlchemyStore,
@@ -54,9 +54,9 @@ class TestExtendedKeyspaceSQLAlchemyStore(TestSQLAlchemyStore,
     def store(self, engine):
         class ExtendedKeyspaceStore(ExtendedKeyspaceMixin, SQLAlchemyStore):
             pass
-        metadata = MetaData(bind=engine)
+        metadata = MetaData()
         store = ExtendedKeyspaceStore(engine, metadata, 'simplekv_test')
         # create table
-        store.table.create()
+        store.table.create(bind=engine)
         yield store
-        metadata.drop_all()
+        metadata.drop_all(bind=engine)


### PR DESCRIPTION
As of SQL Alchemy 2 they fully depreciated the old way of executing queries used by simplekv. I tested these changes to work with SQL Alchemy 1.4.49 and 2.0.21. I'm unsure how old of SQL Alchemy this will work with.

I also got warnings by pytest to change the decorators to the newer name, so I did.